### PR TITLE
Small Fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ genesis-ca/
 - Do not assume file structure beyond what's documented here — ask if uncertain
 - When building new node types, follow the established pattern of existing nodes (compile method, port definitions, UI component)
 - **Documentation consistency:** When changing features, update all three sources of truth: the code, `src/help/HelpView.tsx` (in-app Help tab), and the root `README.md`. These must remain consistent with each other.
-- **Pre-commit type check:** Vite dev server does NOT type-check — always run `npx tsc --noEmit` before committing to catch TypeScript errors that will fail the CI build (`tsc -b`).
+- **Pre-commit type check:** Vite dev server does NOT type-check — always run `npx tsc -b` before committing to catch TypeScript errors that will fail the CI build. Note: `npx tsc --noEmit` (without `-b`) silently checks nothing because the root tsconfig has `"files": []` and only project references.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GenesisCA <sup>v1.1.0</sup>
+# GenesisCA <sup>v1.2.0</sup>
 
 An IDE for modeling and simulating Cellular Automata, built as a self-contained browser application.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genesis-ca",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genesis-ca",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-ca",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "GPL-3.0-only",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ function AppInner() {
               1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
           </svg>
         </a>
-        <span className={styles.title}>GenesisCA <span className={styles.version}>v1.1.0</span></span>
+        <span className={styles.title}>GenesisCA <span className={styles.version}>v1.2.0</span></span>
         <div className={styles.navTabs}>
           <button
             className={`${styles.navButton} ${mode === 'modeler' ? styles.navButtonActive : ''}`}

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -625,17 +625,6 @@ export function SimulatorView() {
     setRecordFrameCount(0);
   };
 
-  const handleRecompile = () => {
-    const result = compileModel();
-    if (result.error) { setCompileError(result.error); return; }
-    setCompileError('');
-    setCompiledCode(result.stepCode);
-    workerRef.current?.postMessage({
-      type: 'recompile',
-      stepCode: result.stepCode,
-      inputColorCodes: result.inputColorCodes,
-    });
-  };
 
   const handleCopyCode = () => {
     navigator.clipboard.writeText(compiledCode).catch(() => {});


### PR DESCRIPTION
* Bump version to 1.2.0

* Fix CI build: remove unused handleRecompile, fix tsc command in CLAUDE.md

The root tsconfig.json has "files": [] with only project references, so
`npx tsc --noEmit` silently checks nothing. The correct command is `npx tsc -b`
which follows references to tsconfig.app.json (where noUnusedLocals is enabled).

