### PR TITLE
Add async mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ genesis-ca/
 │   │       ├── GraphEditor.tsx
 │   │       ├── graphState.ts          # Shared mutable state (avoids circular imports between GraphEditor/CaNode)
 │   │       ├── NodeExplorer.tsx        # Right-side searchable node list panel
-│   │       ├── nodes/                # 21 node types (one file each)
+│   │       ├── nodes/                # 26 node types (one file each)
 │   │       └── compiler/
 │   │           └── compile.ts        # Two-pass compiler (hoisted values + flow)
 │   ├── simulator/
@@ -250,10 +250,13 @@ The app is functional with these major systems:
 ### Visual Programming Language (VPL)
 - `src/modeler/vpl/GraphEditor.tsx` — React Flow-based node graph editor
 - `src/modeler/vpl/CaNode.tsx` — Custom node component with per-type config UI
-- `src/modeler/vpl/nodes/` — 25 node types, each in its own file with `compile()` method (3 are async-only: SetNeighborhoodAttribute, GetNeighborAttributeByIndex, SetNeighborAttributeByIndex)
+- `src/modeler/vpl/nodes/` — 26 node types, each in its own file with `compile()` method (2 are async-only: SetNeighborhoodAttribute, SetNeighborAttributeByIndex)
+- Three "event" entry-point nodes: GenerationStep (per-gen logic), InputMapping C→A (brush), OutputMapping A→C (color pass)
 - `src/modeler/vpl/compiler/compile.ts` — Two-pass compiler: hoists values, then emits flow
 - Multi-output nodes (InputColor, GetColorConstant, MacroNode) use `_v${nodeId}_${portId}` naming
-- Multi-root support: Step (per-generation) and InputColor (brush interaction) compile separately
+- Multi-root support: Step (per-generation), InputColor (brush interaction), and OutputMapping (color pass) compile separately
+- OutputMapping functions: loop-wrapped, always sequential (no shuffle), no copy lines; run once after all generation steps complete; skipped in unlimited gens mode via `skipColorPass` flag
+- Paint with OutputMapping: prefers `runColorPass()` over `runStep()` so painting doesn't advance the simulation
 
 ### Simulation Engine (SoA Architecture)
 - `src/simulator/engine/sim.worker.ts` — Web Worker owns grid as Structure of Arrays
@@ -281,7 +284,7 @@ The app is functional with these major systems:
 - Recompile optimization: structural changes reinit worker, graph-only changes send `recompile` message (preserves grid state)
 
 ### Key Patterns
-- Async-only nodes (`ASYNC_ONLY_TYPES` in compile.ts): `setNeighborhoodAttribute`, `setNeighborAttributeByIndex`, `getNeighborAttributeByIndex` — compiler emits error if used in sync mode because copy lines overwrite neighbor writes
+- Async-only nodes (`ASYNC_ONLY_TYPES` in compile.ts): `setNeighborhoodAttribute`, `setNeighborAttributeByIndex` — compiler emits error if used in sync mode because copy lines overwrite neighbor writes. `getNeighborAttributeByIndex` is read-only and works in both modes.
 - Neighbor-write nodes use `if (_ni < total)` guard to protect constant-boundary sentinel from corruption
 - Graph state sync: single debounced sync (100ms) via refs — never use multiple setTimeout callbacks
 - Graph editor mouse: RMB click=context menu, RMB drag=pan (`panOnDrag={[2]}`), LMB click=select, LMB drag=box select (`selectionOnDrag`); simulator: LMB=brush, RMB=pan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ Every GenesisCA model satisfies these theoretical properties:
 1. Cells have unlimited computing power
 2. Cells have N internal attributes (of multiple data types), whose snapshot of values at a given generation is called its "state"
 3. Cells are limited to only access (read) the states of cells in one of the neighborhoods defined in the CA model
-4. Cells can only make changes to themselves, never to the environment around (other cells)
+4. **Writability** — In synchronous (classic) mode, cells can only modify their own attributes. In asynchronous mode, cells can also directly modify the attributes of neighboring cells, enabling movement and mass-conservation rules.
 5. Space and Time are discrete (cells arranged in n-dimensional grid)
-6. All cells update their states simultaneously (synchronously) each passing generation
+6. **Synchronicity** — The model can be either synchronous (all cells update simultaneously each generation — classic CA) or asynchronous (cells update sequentially using a single buffer, enabling number-conserving models where elements move across the grid without being created or destroyed). Async supports three update schemes: Random Order (Fisher-Yates), Random Independent (with replacement), Cyclic (fixed order from init).
 
 ### Simulation Essentials (Color Mappings)
 
@@ -250,18 +250,20 @@ The app is functional with these major systems:
 ### Visual Programming Language (VPL)
 - `src/modeler/vpl/GraphEditor.tsx` — React Flow-based node graph editor
 - `src/modeler/vpl/CaNode.tsx` — Custom node component with per-type config UI
-- `src/modeler/vpl/nodes/` — 22 node types, each in its own file with `compile()` method
+- `src/modeler/vpl/nodes/` — 25 node types, each in its own file with `compile()` method (3 are async-only: SetNeighborhoodAttribute, GetNeighborAttributeByIndex, SetNeighborAttributeByIndex)
 - `src/modeler/vpl/compiler/compile.ts` — Two-pass compiler: hoists values, then emits flow
 - Multi-output nodes (InputColor, GetColorConstant, MacroNode) use `_v${nodeId}_${portId}` naming
 - Multi-root support: Step (per-generation) and InputColor (brush interaction) compile separately
 
 ### Simulation Engine (SoA Architecture)
 - `src/simulator/engine/sim.worker.ts` — Web Worker owns grid as Structure of Arrays
-- Grid storage: one typed array per attribute (`Uint8Array` bool, `Int32Array` int/tag, `Float64Array` float), double-buffered
+- Grid storage: one typed array per attribute (`Uint8Array` bool, `Int32Array` int/tag, `Float64Array` float), double-buffered (sync) or single-buffer (async)
 - Tag attributes: `Int32Array`, value = index into `tagOptions` string array
 - Color model attributes: stored as 3 entries (`attrId_r`, `attrId_g`, `attrId_b`) in cachedModelAttrs
 - Neighbor access: pre-computed `Int32Array` index tables (built at init, handles torus/constant boundary once)
-- Step function is LOOP-WRAPPED: `(total, r_<attrs>..., w_<attrs>..., nIdx_<nbrs>..., nSz_<nbrs>..., modelAttrs, colors, activeViewer)` — contains the for-loop, called ONCE per step
+- Step function is LOOP-WRAPPED: `(total, r_<attrs>..., w_<attrs>..., nIdx_<nbrs>..., nSz_<nbrs>..., modelAttrs, colors, activeViewer[, order])` — contains the for-loop, called ONCE per step
+- Async mode: `order` param is an Int32Array of shuffled/random cell indices; loop uses `idx = order[_i]` instead of `idx = _i`; r_ and w_ params point to same typed arrays (single buffer); copy lines are skipped; buffer swap is skipped after step
+- Async schemes: `random-order` (Fisher-Yates shuffle per step), `random-independent` (N random picks with replacement), `cyclic` (one-time shuffle at init)
 - InputColor functions remain per-cell: `(_r, _g, _b, idx, r_<attrs>..., ...)`
 - GetNeighborsAttribute uses `_scr_<nodeId>` scratch arrays declared before the loop — never allocate in hot path
 - NEVER use `fn(...args)` in per-cell loops — V8 megamorphic spread kills performance
@@ -279,6 +281,8 @@ The app is functional with these major systems:
 - Recompile optimization: structural changes reinit worker, graph-only changes send `recompile` message (preserves grid state)
 
 ### Key Patterns
+- Async-only nodes (`ASYNC_ONLY_TYPES` in compile.ts): `setNeighborhoodAttribute`, `setNeighborAttributeByIndex`, `getNeighborAttributeByIndex` — compiler emits error if used in sync mode because copy lines overwrite neighbor writes
+- Neighbor-write nodes use `if (_ni < total)` guard to protect constant-boundary sentinel from corruption
 - Graph state sync: single debounced sync (100ms) via refs — never use multiple setTimeout callbacks
 - Graph editor mouse: RMB click=context menu, RMB drag=pan (`panOnDrag={[2]}`), LMB click=select, LMB drag=box select (`selectionOnDrag`); simulator: LMB=brush, RMB=pan
 - Shared mutable state: `graphState.ts` holds module-level variables (`isConnectingGlobal`, `showPortLabelsGlobal`, `connectingFrom`) to avoid circular imports between GraphEditor↔CaNode

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ A complete GenesisCA model definition consists of:
 
 ### The Modeler
 - **Properties Panel** — model metadata, grid dimensions, boundary treatment (torus/constant), update mode (synchronous/asynchronous), tags
-- **Attributes Panel** — cell and model attributes with type-specific default value controls (bool, integer, float, tag, list, color)
+- **Attributes Panel** — cell and model attributes with type-specific default value controls (bool, integer, float, tag, color)
 - **Neighborhoods Panel** — interactive grid editor with per-neighborhood margin, and a Duplicate button for quick variations
 - **Mappings Panel** — Attribute-to-Color and Color-to-Attribute mapping definitions
-- **Graph Editor** — 25 node types across 6 categories (flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
+- **Graph Editor** — 26 node types across 7 categories (event, flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
 - **Connection validation** — prevents incompatible connections (flow/value), cycles, and duplicate inputs; compatible ports highlight during drag
 - **Inline Port Widgets** — input ports show small value editors (number/bool) when unconnected, eliminating the need for constant nodes in simple cases
 - **Node Collapse/Expand** — double-click any node to collapse it; constants show their value; collapsed nodes temporarily expand when connecting edges
@@ -81,7 +81,7 @@ A complete GenesisCA model definition consists of:
 ### Asynchronous Mode
 - **Update Mode** — choose Synchronous (classic CA) or Asynchronous (sequential updates with single buffer) in Model Properties
 - **Update Schemes** — Random Order, Random Independent, or Cyclic — balancing accuracy vs. performance
-- **Async-only nodes** — Set Neighborhood Attribute, Set/Get Neighbor Attr By Index for number-conserving movement patterns
+- **Async-only nodes** — Set Neighborhood Attribute, Set Neighbor Attr By Index for number-conserving movement patterns. Get Neighbor Attr By Index works in both modes.
 
 ### The Simulator
 - **Transport bar** — Play/Pause/Step/Reset with FPS and Gens/Frame sliders, keyboard shortcuts (Space=step, Enter=play/pause, Esc=reset)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Every GenesisCA model satisfies these theoretical properties:
 1. Cells have unlimited computing power
 2. Cells have N internal attributes (of multiple data types), whose snapshot of values at a given generation is called its "state"
 3. Cells are limited to only access (read) the states of cells in one of the neighborhoods defined in the CA model
-4. Cells can only make changes to themselves, never to the environment around (other cells)
+4. **Writability** — In synchronous (classic) mode, cells can only modify their own attributes. In asynchronous mode, cells can also directly modify the attributes of neighboring cells, enabling movement and mass-conservation rules.
 5. Space and Time are discrete (cells arranged in n-dimensional grid)
-6. All cells update their states simultaneously (synchronously) each passing generation
+6. **Synchronicity** — Model can be either synchronous (all cells update simultaneously — classic CA) or asynchronous (cells update sequentially, enabling number-conserving models)
 
 ### Simulation Essentials (Color Mappings)
 
@@ -61,11 +61,11 @@ A complete GenesisCA model definition consists of:
 ## Features
 
 ### The Modeler
-- **Properties Panel** — model metadata, grid dimensions, boundary treatment (torus/constant), tags
+- **Properties Panel** — model metadata, grid dimensions, boundary treatment (torus/constant), update mode (synchronous/asynchronous), tags
 - **Attributes Panel** — cell and model attributes with type-specific default value controls (bool, integer, float, tag, list, color)
 - **Neighborhoods Panel** — interactive grid editor with per-neighborhood margin, and a Duplicate button for quick variations
 - **Mappings Panel** — Attribute-to-Color and Color-to-Attribute mapping definitions
-- **Graph Editor** — 22 node types across 6 categories (flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
+- **Graph Editor** — 25 node types across 6 categories (flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
 - **Connection validation** — prevents incompatible connections (flow/value), cycles, and duplicate inputs; compatible ports highlight during drag
 - **Inline Port Widgets** — input ports show small value editors (number/bool) when unconnected, eliminating the need for constant nodes in simple cases
 - **Node Collapse/Expand** — double-click any node to collapse it; constants show their value; collapsed nodes temporarily expand when connecting edges
@@ -77,6 +77,11 @@ A complete GenesisCA model definition consists of:
 - **Copy/Paste/Duplicate** — Ctrl+C/V/X/D, context menu on single nodes and selections, paste at right-click location
 - **Groups & Comments** — visual organization tools; Undo Group dissolves a group and selects all contained nodes
 - **Edge management** — double-click any edge to delete it
+
+### Asynchronous Mode
+- **Update Mode** — choose Synchronous (classic CA) or Asynchronous (sequential updates with single buffer) in Model Properties
+- **Update Schemes** — Random Order, Random Independent, or Cyclic — balancing accuracy vs. performance
+- **Async-only nodes** — Set Neighborhood Attribute, Set/Get Neighbor Attr By Index for number-conserving movement patterns
 
 ### The Simulator
 - **Transport bar** — Play/Pause/Step/Reset with FPS and Gens/Frame sliders, keyboard shortcuts (Space=step, Enter=play/pause, Esc=reset)

--- a/public/models/Coagulation.gcaproj
+++ b/public/models/Coagulation.gcaproj
@@ -16,7 +16,9 @@
       "customizable params",
       "alternative neighborhoods",
       "outer totalistic"
-    ]
+    ],
+    "updateMode": "synchronous",
+    "asyncScheme": "random-order"
   },
   "attributes": [
     {
@@ -138,7 +140,8 @@
           3,
           1
         ]
-      ]
+      ],
+      "margin": 2
     },
     {
       "id": "new_neighborhood_mnozpfe0xnf",
@@ -201,7 +204,8 @@
           1,
           -2
         ]
-      ]
+      ],
+      "margin": 2
     },
     {
       "id": "new_neighborhood_mnozq335pox",
@@ -264,7 +268,8 @@
           2,
           2
         ]
-      ]
+      ],
+      "margin": 2
     }
   ],
   "mappings": [
@@ -316,72 +321,74 @@
   ],
   "graphNodes": [
     {
-      "id": "nmnp0zrcdp9q",
+      "id": "nmnscap1v4i2",
       "type": "groupNode",
       "position": {
-        "x": -1340,
-        "y": 800
-      },
-      "data": {
-        "label": "Update Output Color Domain View",
-        "width": 1360,
-        "height": 580,
-        "nodeType": "group",
-        "config": {}
-      }
-    },
-    {
-      "id": "nmnp0z7vhu0w",
-      "type": "groupNode",
-      "position": {
-        "x": -860,
-        "y": 120
-      },
-      "data": {
-        "label": "Update Output Color Trace/Binary",
-        "width": 750,
-        "height": 600,
-        "nodeType": "group",
-        "config": {}
-      }
-    },
-    {
-      "id": "nmno04wj3pc6",
-      "type": "groupNode",
-      "position": {
-        "x": -90,
-        "y": 300
-      },
-      "data": {
-        "label": "Trace of live cells",
-        "width": 820,
-        "height": 572.9326512439673,
-        "nodeType": "group",
-        "config": {},
-        "groupColor": "#819744"
-      }
-    },
-    {
-      "id": "nmno03hqnw4f",
-      "type": "groupNode",
-      "position": {
-        "x": -320,
-        "y": -980
+        "x": -200,
+        "y": -900
       },
       "data": {
         "label": "Color Input effect (manual brush or image load)",
         "width": 692.1230707425473,
-        "height": 770,
+        "height": 700,
         "nodeType": "group",
         "config": {}
+      }
+    },
+    {
+      "id": "nmnsc93u3yrr",
+      "type": "groupNode",
+      "position": {
+        "x": -100,
+        "y": 620
+      },
+      "data": {
+        "label": "Update Output Color Domain View",
+        "width": 1400,
+        "height": 600,
+        "nodeType": "group",
+        "config": {},
+        "groupColor": "#ab4444"
+      }
+    },
+    {
+      "id": "nmnsc8dextu9",
+      "type": "groupNode",
+      "position": {
+        "x": -1020,
+        "y": 140
+      },
+      "data": {
+        "label": "Update Output Color Trace/Binary",
+        "width": 870,
+        "height": 600,
+        "nodeType": "group",
+        "config": {},
+        "groupColor": "#80722d"
+      }
+    },
+    {
+      "id": "nmnsc7n8fqs6",
+      "type": "groupNode",
+      "position": {
+        "x": 0,
+        "y": 160
+      },
+      "data": {
+        "label": "Trace of Living cells",
+        "width": 790,
+        "height": 360,
+        "nodeType": "group",
+        "config": {},
+        "groupColor": "#32856c"
       }
     },
     {
       "id": "n4",
       "type": "caNode",
       "position": {
-        "x": -820,
-        "y": -60
+        "x": -440,
+        "y": -80
       },
       "data": {
         "nodeType": "step",
@@ -392,13 +399,14 @@
       "id": "n5",
       "type": "caNode",
       "position": {
-        "x": 880,
-        "y": 200
+        "x": 780,
+        "y": 60
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
-          "attributeId": "alive"
+          "attributeId": "alive",
+          "_port_value": "true"
         }
       }
     },
@@ -406,8 +414,8 @@
       "id": "n6",
       "type": "caNode",
       "position": {
-        "x": 81.83515404435137,
-        "y": 47.21700913282251
+        "x": 72,
+        "y": -33
       },
       "data": {
         "nodeType": "conditional",
@@ -418,8 +426,8 @@
       "id": "n7",
       "type": "caNode",
       "position": {
-        "x": -120,
-        "y": 100
+        "x": -130,
+        "y": 20
       },
       "data": {
         "nodeType": "getCellAttribute",
@@ -432,8 +440,8 @@
       "id": "n8",
       "type": "caNode",
       "position": {
-        "x": 520,
-        "y": 0
+        "x": 510,
+        "y": -120
       },
       "data": {
         "nodeType": "conditional",
@@ -444,8 +452,8 @@
       "id": "n9",
       "type": "caNode",
       "position": {
-        "x": 520,
-        "y": 160
+        "x": 510,
+        "y": 40
       },
       "data": {
         "nodeType": "conditional",
@@ -453,26 +461,11 @@
       }
     },
     {
-      "id": "n14",
-      "type": "caNode",
-      "position": {
-        "x": 700,
-        "y": 220
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "bool",
-          "constValue": "true"
-        }
-      }
-    },
-    {
       "id": "n20",
       "type": "caNode",
       "position": {
-        "x": 880,
-        "y": 0
+        "x": 780,
+        "y": -140
       },
       "data": {
         "nodeType": "setAttribute",
@@ -486,14 +479,15 @@
       "type": "caNode",
       "position": {
         "x": 700,
-        "y": 60
+        "y": -60
       },
       "data": {
         "nodeType": "getConstant",
         "config": {
           "constType": "bool",
           "constValue": "false"
-        }
+        },
+        "isCollapsed": true
       }
     },
     {
@@ -501,14 +495,14 @@
       "type": "caNode",
       "position": {
         "x": 40,
-        "y": 40
+        "y": 60
       },
       "data": {
         "nodeType": "inputColor",
         "config": {
           "mappingId": "paint"
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -516,14 +510,14 @@
       "type": "caNode",
       "position": {
         "x": 233.03100024947162,
-        "y": 147.33550225570912
+        "y": 167.33550225570912
       },
       "data": {
         "nodeType": "statement",
         "config": {
           "operation": ">"
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -531,7 +525,7 @@
       "type": "caNode",
       "position": {
         "x": 80,
-        "y": 540
+        "y": 560
       },
       "data": {
         "nodeType": "getRandom",
@@ -540,23 +534,7 @@
           "min": "0",
           "max": "1"
         },
-        "parentId": "nmno03hqnw4f"
-      }
-    },
-    {
-      "id": "nmnn6pdd7osw",
-      "type": "caNode",
-      "position": {
-        "x": 40,
-        "y": 187.97712308379084
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "integer",
-          "constValue": "0"
-        },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -564,14 +542,14 @@
       "type": "caNode",
       "position": {
         "x": 412.7335237586544,
-        "y": 60
+        "y": 80
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
           "attributeId": "alive"
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -579,14 +557,14 @@
       "type": "caNode",
       "position": {
         "x": 72.12307074254721,
-        "y": 326.31200399284046
+        "y": 346.31200399284046
       },
       "data": {
         "nodeType": "inputColor",
         "config": {
           "mappingId": "new_mapping_2"
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -594,157 +572,100 @@
       "type": "caNode",
       "position": {
         "x": 452.1230707425472,
-        "y": 326.31200399284046
+        "y": 346.31200399284046
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
           "attributeId": "alive"
         },
-        "parentId": "nmno03hqnw4f"
-      }
-    },
-    {
-      "id": "nmnnb8mx6q0v",
-      "type": "caNode",
-      "position": {
-        "x": 239.25891934636195,
-        "y": 64.17703631160799
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "integer",
-          "constValue": "200"
-        },
-        "parentId": "nmno04wj3pc6"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
       "id": "nmnnb8qcry9i",
       "type": "caNode",
       "position": {
-        "x": 590,
-        "y": 40
+        "x": 550,
+        "y": 60
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
-          "attributeId": "new_attribute_2"
+          "attributeId": "new_attribute_2",
+          "_port_value": "200"
         },
-        "parentId": "nmno04wj3pc6"
+        "parentId": "nmnsc7n8fqs6"
       }
     },
     {
       "id": "nmnnbaxs9dv5",
       "type": "caNode",
       "position": {
-        "x": 590,
-        "y": 200
+        "x": 540,
+        "y": 160
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
           "attributeId": "new_attribute_2"
         },
-        "parentId": "nmno04wj3pc6"
+        "parentId": "nmnsc7n8fqs6"
       }
     },
     {
       "id": "nmnnbdeay51o",
       "type": "caNode",
       "position": {
-        "x": 38.30712352184321,
-        "y": 196.13910139512632
+        "x": 40,
+        "y": 200
       },
       "data": {
         "nodeType": "getCellAttribute",
         "config": {
           "attributeId": "new_attribute_2"
         },
-        "parentId": "nmno04wj3pc6"
+        "parentId": "nmnsc7n8fqs6",
+        "isCollapsed": true
       }
     },
     {
       "id": "nmnnbdiqxonq",
       "type": "caNode",
       "position": {
-        "x": 240.02052822405187,
-        "y": 228.93802898898127
+        "x": 180,
+        "y": 180
       },
       "data": {
         "nodeType": "arithmeticOperator",
         "config": {
-          "operation": "-"
+          "operation": "-",
+          "_port_y": "5"
         },
-        "parentId": "nmno04wj3pc6"
-      }
-    },
-    {
-      "id": "nmnnbdtkhyq6",
-      "type": "caNode",
-      "position": {
-        "x": 30,
-        "y": 300
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "integer",
-          "constValue": "5"
-        },
-        "parentId": "nmno04wj3pc6"
+        "parentId": "nmnsc7n8fqs6",
+        "isCollapsed": false
       }
     },
     {
       "id": "nmnnbdzlxupr",
       "type": "caNode",
       "position": {
-        "x": 410,
-        "y": 240
+        "x": 360,
+        "y": 220
       },
       "data": {
         "nodeType": "arithmeticOperator",
         "config": {
           "operation": "max"
         },
-        "parentId": "nmno04wj3pc6"
-      }
-    },
-    {
-      "id": "nmnnbe8sqv9o",
-      "type": "caNode",
-      "position": {
-        "x": 230,
-        "y": 320
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "integer",
-          "constValue": "0"
-        },
-        "parentId": "nmno04wj3pc6"
-      }
-    },
-    {
-      "id": "nmnnbfh7s6xj",
-      "type": "caNode",
-      "position": {
-        "x": -566,
-        "y": 44
-      },
-      "data": {
-        "nodeType": "sequence",
-        "config": {},
-        "label": "Update State then Color Output"
+        "parentId": "nmnsc7n8fqs6"
       }
     },
     {
       "id": "nmnnbgx6s4jf",
       "type": "caNode",
       "position": {
-        "x": 510,
+        "x": 630,
         "y": 340
       },
       "data": {
@@ -752,81 +673,70 @@
         "config": {
           "mappingId": "new_mapping_6"
         },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9"
       }
     },
     {
       "id": "nmnnbh86pr7v",
       "type": "caNode",
       "position": {
-        "x": 311,
-        "y": 345
+        "x": 480,
+        "y": 380
       },
       "data": {
         "nodeType": "getCellAttribute",
         "config": {
           "attributeId": "new_attribute_2"
         },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9",
+        "isCollapsed": true
       }
     },
     {
       "id": "nmnncdpy7jkk",
       "type": "caNode",
       "position": {
-        "x": 227,
+        "x": 347,
         "y": 141
       },
       "data": {
         "nodeType": "conditional",
         "config": {},
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9"
       }
     },
     {
       "id": "nmnnce6dqlfi",
       "type": "caNode",
       "position": {
-        "x": 510,
+        "x": 630,
         "y": 200
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
-          "mappingId": "new_mapping_6"
+          "mappingId": "new_mapping_6",
+          "_port_r": "200",
+          "_port_g": "200",
+          "_port_b": "200"
         },
-        "parentId": "nmnp0z7vhu0w"
-      }
-    },
-    {
-      "id": "nmnncecbk5u3",
-      "type": "caNode",
-      "position": {
-        "x": 300,
-        "y": 240
-      },
-      "data": {
-        "nodeType": "getConstant",
-        "config": {
-          "constType": "integer",
-          "constValue": "200"
-        },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9"
       }
     },
     {
       "id": "nmnncgefih9c",
       "type": "caNode",
       "position": {
-        "x": 40,
-        "y": 142
+        "x": 260,
+        "y": 180
       },
       "data": {
         "nodeType": "getCellAttribute",
         "config": {
           "attributeId": "alive"
         },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9",
+        "isCollapsed": true
       }
     },
     {
@@ -834,14 +744,14 @@
       "type": "caNode",
       "position": {
         "x": 272.1230707425472,
-        "y": 386.31200399284046
+        "y": 406.31200399284046
       },
       "data": {
         "nodeType": "statement",
         "config": {
           "operation": ">="
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
@@ -849,22 +759,22 @@
       "type": "caNode",
       "position": {
         "x": 60,
-        "y": 460
+        "y": 480
       },
       "data": {
         "nodeType": "getModelAttribute",
         "config": {
           "attributeId": "new_attribute_4"
         },
-        "parentId": "nmno03hqnw4f"
+        "parentId": "nmnscap1v4i2"
       }
     },
     {
       "id": "nmno12xxa9g2",
       "type": "caNode",
       "position": {
-        "x": 340,
-        "y": 80
+        "x": 330,
+        "y": -40
       },
       "data": {
         "nodeType": "macro",
@@ -878,36 +788,37 @@
       "id": "nmnp006skwrv",
       "type": "caNode",
       "position": {
-        "x": 200,
-        "y": 180
+        "x": 340,
+        "y": 200
       },
       "data": {
         "nodeType": "conditional",
         "config": {},
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp00d2rbux",
       "type": "caNode",
       "position": {
-        "x": 40,
-        "y": 200
+        "x": 220,
+        "y": 240
       },
       "data": {
         "nodeType": "getCellAttribute",
         "config": {
           "attributeId": "new_attribute_mnozx9w25wi"
         },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr",
+        "isCollapsed": true
       }
     },
     {
       "id": "nmnp039iefxc",
       "type": "caNode",
       "position": {
-        "x": 880,
-        "y": 100
+        "x": 780,
+        "y": -40
       },
       "data": {
         "nodeType": "setAttribute",
@@ -920,22 +831,25 @@
       "id": "nmnp0aclxggq",
       "type": "caNode",
       "position": {
-        "x": 510,
+        "x": 630,
         "y": 60
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
-          "mappingId": "new_mapping_mnozs1m8oh2"
+          "mappingId": "new_mapping_mnozs1m8oh2",
+          "_port_r": "200",
+          "_port_g": "200",
+          "_port_b": "200"
         },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9"
       }
     },
     {
       "id": "nmnp0c4sj7fx",
       "type": "caNode",
       "position": {
-        "x": 510,
+        "x": 630,
         "y": 460
       },
       "data": {
@@ -943,60 +857,46 @@
         "config": {
           "mappingId": "new_mapping_mnozs1m8oh2"
         },
-        "parentId": "nmnp0z7vhu0w"
+        "parentId": "nmnsc8dextu9"
       }
     },
     {
       "id": "nmnp0dn8xez5",
       "type": "caNode",
       "position": {
-        "x": 380,
-        "y": 260
+        "x": 520,
+        "y": 280
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
-          "mappingId": "new_mapping_mnozsm1bunm"
+          "mappingId": "new_mapping_mnozsm1bunm",
+          "_port_r": "200",
+          "_port_g": "200",
+          "_port_b": "200"
         },
-        "parentId": "nmnp0zrcdp9q"
-      }
-    },
-    {
-      "id": "nmnp0dvhuz6y",
-      "type": "caNode",
-      "position": {
-        "x": 200,
-        "y": 280
-      },
-      "data": {
-        "nodeType": "getColorConstant",
-        "config": {
-          "r": "200",
-          "g": "200",
-          "b": "200"
-        },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0esjct5l",
       "type": "caNode",
       "position": {
-        "x": 580,
-        "y": 180
+        "x": 720,
+        "y": 200
       },
       "data": {
         "nodeType": "conditional",
         "config": {},
         "label": "Horizontal pattern",
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0f94juy2",
       "type": "caNode",
       "position": {
-        "x": 360,
+        "x": 500,
         "y": 60
       },
       "data": {
@@ -1005,15 +905,15 @@
           "neighborhoodId": "new_neighborhood_mnozq335pox",
           "attributeId": "alive"
         },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0qf1athz",
       "type": "caNode",
       "position": {
-        "x": 380,
-        "y": 140
+        "x": 520,
+        "y": 160
       },
       "data": {
         "nodeType": "macro",
@@ -1021,29 +921,29 @@
           "macroDefId": "macro_mnp0qf19"
         },
         "label": "Test pattern",
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0tma79m0",
       "type": "caNode",
       "position": {
-        "x": 780,
-        "y": 360
+        "x": 920,
+        "y": 380
       },
       "data": {
         "nodeType": "conditional",
         "config": {},
         "label": "Vertical Pattern",
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0tyv7zim",
       "type": "caNode",
       "position": {
-        "x": 600,
-        "y": 400
+        "x": 740,
+        "y": 420
       },
       "data": {
         "nodeType": "macro",
@@ -1051,15 +951,15 @@
           "macroDefId": "macro_mnp0qf19"
         },
         "label": "Test pattern",
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0uax6utd",
       "type": "caNode",
       "position": {
-        "x": 580,
-        "y": 300
+        "x": 720,
+        "y": 320
       },
       "data": {
         "nodeType": "getNeighborsAttribute",
@@ -1067,99 +967,72 @@
           "neighborhoodId": "new_neighborhood_mnozpfe0xnf",
           "attributeId": "alive"
         },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0vey25o7",
       "type": "caNode",
       "position": {
-        "x": 940,
-        "y": 120
+        "x": 1160,
+        "y": 160
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
-          "mappingId": "new_mapping_mnozsm1bunm"
+          "mappingId": "new_mapping_mnozsm1bunm",
+          "_port_r": "105",
+          "_port_g": "65",
+          "_port_b": "15"
         },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0vnst383",
       "type": "caNode",
       "position": {
-        "x": 960,
-        "y": 440
+        "x": 1160,
+        "y": 460
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
           "mappingId": "new_mapping_mnozsm1bunm"
         },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp0vxupvy8",
       "type": "caNode",
       "position": {
-        "x": 1120,
-        "y": 280
+        "x": 1160,
+        "y": 320
       },
       "data": {
         "nodeType": "setColorViewer",
         "config": {
-          "mappingId": "new_mapping_mnozsm1bunm"
+          "mappingId": "new_mapping_mnozsm1bunm",
+          "_port_r": "182",
+          "_port_g": "40",
+          "_port_b": "9"
         },
-        "parentId": "nmnp0zrcdp9q"
-      }
-    },
-    {
-      "id": "nmnp0w414apl",
-      "type": "caNode",
-      "position": {
-        "x": 960,
-        "y": 300
-      },
-      "data": {
-        "nodeType": "getColorConstant",
-        "config": {
-          "r": "182",
-          "g": "40",
-          "b": "9"
-        },
-        "parentId": "nmnp0zrcdp9q"
-      }
-    },
-    {
-      "id": "nmnp0xw33v5g",
-      "type": "caNode",
-      "position": {
-        "x": 780,
-        "y": 140
-      },
-      "data": {
-        "nodeType": "getColorConstant",
-        "config": {
-          "r": "105",
-          "g": "65",
-          "b": "15"
-        },
-        "parentId": "nmnp0zrcdp9q"
+        "parentId": "nmnsc93u3yrr"
       }
     },
     {
       "id": "nmnp195v0b2o",
       "type": "caNode",
       "position": {
-        "x": -220,
-        "y": -60
+        "x": 80,
+        "y": -120
       },
       "data": {
         "nodeType": "setAttribute",
         "config": {
-          "attributeId": "new_attribute_mnozx9w25wi"
+          "attributeId": "new_attribute_mnozx9w25wi",
+          "_port_value": "true"
         }
       }
     },
@@ -1167,8 +1040,8 @@
       "id": "nmnp19vq3i7j",
       "type": "caNode",
       "position": {
-        "x": -560,
-        "y": -60
+        "x": -200,
+        "y": -80
       },
       "data": {
         "nodeType": "sequence",
@@ -1176,18 +1049,48 @@
       }
     },
     {
-      "id": "nmnp1abrkvxc",
+      "id": "nmnsbw1v4bsf",
       "type": "caNode",
       "position": {
-        "x": -380,
-        "y": -20
+        "x": 40,
+        "y": 140
       },
       "data": {
-        "nodeType": "getConstant",
+        "nodeType": "outputMapping",
         "config": {
-          "constType": "bool",
-          "constValue": "true"
-        }
+          "mappingId": "new_mapping_6"
+        },
+        "parentId": "nmnsc8dextu9"
+      }
+    },
+    {
+      "id": "nmnsbw4uxcvx",
+      "type": "caNode",
+      "position": {
+        "x": 40,
+        "y": 60
+      },
+      "data": {
+        "nodeType": "outputMapping",
+        "config": {
+          "mappingId": "new_mapping_mnozs1m8oh2"
+        },
+        "parentId": "nmnsc8dextu9"
+      }
+    },
+    {
+      "id": "nmnsbwpywakk",
+      "type": "caNode",
+      "position": {
+        "x": 40,
+        "y": 180
+      },
+      "data": {
+        "nodeType": "outputMapping",
+        "config": {
+          "mappingId": "new_mapping_mnozsm1bunm"
+        },
+        "parentId": "nmnsc93u3yrr"
       }
     }
   ],
@@ -1212,13 +1115,6 @@
       "target": "n5",
       "sourceHandle": "output_flow_then",
       "targetHandle": "input_flow_do"
-    },
-    {
-      "id": "xy-edge__n14output_value_value-n5input_value_value",
-      "source": "n14",
-      "target": "n5",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_value"
     },
     {
       "id": "xy-edge__n6output_flow_then-n8input_flow_check",
@@ -1249,13 +1145,6 @@
       "targetHandle": "input_value_x"
     },
     {
-      "id": "xy-edge__nmnn6pdd7oswoutput_value_value-nmnn6niv353rinput_value_y",
-      "source": "nmnn6pdd7osw",
-      "target": "nmnn6niv353r",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_y"
-    },
-    {
       "id": "xy-edge__nmnn6ml8mgcsoutput_flow_do-nmnn6pqqzgscinput_flow_do",
       "source": "nmnn6ml8mgcs",
       "target": "nmnn6pqqzgsc",
@@ -1275,13 +1164,6 @@
       "target": "nmnn6qulnxrx",
       "sourceHandle": "output_flow_do",
       "targetHandle": "input_flow_do"
-    },
-    {
-      "id": "xy-edge__nmnnb8mx6q0voutput_value_value-nmnnb8qcry9iinput_value_value",
-      "source": "nmnnb8mx6q0v",
-      "target": "nmnnb8qcry9i",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_value"
     },
     {
       "id": "xy-edge__n6output_flow_then-nmnnb8qcry9iinput_flow_do",
@@ -1305,25 +1187,11 @@
       "targetHandle": "input_value_x"
     },
     {
-      "id": "xy-edge__nmnnbdtkhyq6output_value_value-nmnnbdiqxonqinput_value_y",
-      "source": "nmnnbdtkhyq6",
-      "target": "nmnnbdiqxonq",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_y"
-    },
-    {
       "id": "xy-edge__nmnnbdiqxonqoutput_value_result-nmnnbdzlxuprinput_value_x",
       "source": "nmnnbdiqxonq",
       "target": "nmnnbdzlxupr",
       "sourceHandle": "output_value_result",
       "targetHandle": "input_value_x"
-    },
-    {
-      "id": "xy-edge__nmnnbe8sqv9ooutput_value_value-nmnnbdzlxuprinput_value_y",
-      "source": "nmnnbe8sqv9o",
-      "target": "nmnnbdzlxupr",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_y"
     },
     {
       "id": "xy-edge__nmnnbdzlxuproutput_value_result-nmnnbaxs9dv5input_value_value",
@@ -1333,13 +1201,6 @@
       "targetHandle": "input_value_value"
     },
     {
-      "id": "xy-edge__nmnnbfh7s6xjoutput_flow_first-n6input_flow_check",
-      "source": "nmnnbfh7s6xj",
-      "target": "n6",
-      "sourceHandle": "output_flow_first",
-      "targetHandle": "input_flow_check"
-    },
-    {
       "id": "xy-edge__nmnnbh86pr7voutput_value_value-nmnnbgx6s4jfinput_value_r",
       "source": "nmnnbh86pr7v",
       "target": "nmnnbgx6s4jf",
@@ -1347,39 +1208,11 @@
       "targetHandle": "input_value_r"
     },
     {
-      "id": "xy-edge__nmnnbfh7s6xjoutput_flow_then-nmnncdpy7jkkinput_flow_check",
-      "source": "nmnnbfh7s6xj",
-      "target": "nmnncdpy7jkk",
-      "sourceHandle": "output_flow_then",
-      "targetHandle": "input_flow_check"
-    },
-    {
       "id": "xy-edge__nmnncdpy7jkkoutput_flow_then-nmnnce6dqlfiinput_flow_do",
       "source": "nmnncdpy7jkk",
       "target": "nmnnce6dqlfi",
       "sourceHandle": "output_flow_then",
       "targetHandle": "input_flow_do"
-    },
-    {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_r",
-      "source": "nmnncecbk5u3",
-      "target": "nmnnce6dqlfi",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_r"
-    },
-    {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_b",
-      "source": "nmnncecbk5u3",
-      "target": "nmnnce6dqlfi",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_b"
-    },
-    {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_g",
-      "source": "nmnncecbk5u3",
-      "target": "nmnnce6dqlfi",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_g"
     },
     {
       "id": "xy-edge__nmnncdpy7jkkoutput_flow_else-nmnnbgx6s4jfinput_flow_do",
@@ -1431,13 +1264,6 @@
       "targetHandle": "input_value_x"
     },
     {
-      "id": "xy-edge__nmnnbfh7s6xjoutput_flow_then-nmnp006skwrvinput_flow_check",
-      "source": "nmnnbfh7s6xj",
-      "target": "nmnp006skwrv",
-      "sourceHandle": "output_flow_then",
-      "targetHandle": "input_flow_check"
-    },
-    {
       "id": "xy-edge__nmnp00d2rbuxoutput_value_value-nmnp006skwrvinput_value_condition",
       "source": "nmnp00d2rbux",
       "target": "nmnp006skwrv",
@@ -1473,27 +1299,6 @@
       "targetHandle": "input_flow_do"
     },
     {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnp0aclxggqinput_value_r",
-      "source": "nmnncecbk5u3",
-      "target": "nmnp0aclxggq",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_r"
-    },
-    {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnp0aclxggqinput_value_g",
-      "source": "nmnncecbk5u3",
-      "target": "nmnp0aclxggq",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_g"
-    },
-    {
-      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnp0aclxggqinput_value_b",
-      "source": "nmnncecbk5u3",
-      "target": "nmnp0aclxggq",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_b"
-    },
-    {
       "id": "xy-edge__nmnncdpy7jkkoutput_flow_else-nmnp0c4sj7fxinput_flow_do",
       "source": "nmnncdpy7jkk",
       "target": "nmnp0c4sj7fx",
@@ -1506,27 +1311,6 @@
       "target": "nmnp0dn8xez5",
       "sourceHandle": "output_flow_else",
       "targetHandle": "input_flow_do"
-    },
-    {
-      "id": "xy-edge__nmnp0dvhuz6youtput_value_r-nmnp0dn8xez5input_value_r",
-      "source": "nmnp0dvhuz6y",
-      "target": "nmnp0dn8xez5",
-      "sourceHandle": "output_value_r",
-      "targetHandle": "input_value_r"
-    },
-    {
-      "id": "xy-edge__nmnp0dvhuz6youtput_value_g-nmnp0dn8xez5input_value_g",
-      "source": "nmnp0dvhuz6y",
-      "target": "nmnp0dn8xez5",
-      "sourceHandle": "output_value_g",
-      "targetHandle": "input_value_g"
-    },
-    {
-      "id": "xy-edge__nmnp0dvhuz6youtput_value_b-nmnp0dn8xez5input_value_b",
-      "source": "nmnp0dvhuz6y",
-      "target": "nmnp0dn8xez5",
-      "sourceHandle": "output_value_b",
-      "targetHandle": "input_value_b"
     },
     {
       "id": "xy-edge__nmnp006skwrvoutput_flow_then-nmnp0esjct5linput_flow_check",
@@ -1599,48 +1383,6 @@
       "targetHandle": "input_flow_do"
     },
     {
-      "id": "xy-edge__nmnp0w414aploutput_value_b-nmnp0vxupvy8input_value_b",
-      "source": "nmnp0w414apl",
-      "target": "nmnp0vxupvy8",
-      "sourceHandle": "output_value_b",
-      "targetHandle": "input_value_b"
-    },
-    {
-      "id": "xy-edge__nmnp0w414aploutput_value_g-nmnp0vxupvy8input_value_g",
-      "source": "nmnp0w414apl",
-      "target": "nmnp0vxupvy8",
-      "sourceHandle": "output_value_g",
-      "targetHandle": "input_value_g"
-    },
-    {
-      "id": "xy-edge__nmnp0w414aploutput_value_r-nmnp0vxupvy8input_value_r",
-      "source": "nmnp0w414apl",
-      "target": "nmnp0vxupvy8",
-      "sourceHandle": "output_value_r",
-      "targetHandle": "input_value_r"
-    },
-    {
-      "id": "xy-edge__nmnp0xw33v5goutput_value_r-nmnp0vey25o7input_value_r",
-      "source": "nmnp0xw33v5g",
-      "target": "nmnp0vey25o7",
-      "sourceHandle": "output_value_r",
-      "targetHandle": "input_value_r"
-    },
-    {
-      "id": "xy-edge__nmnp0xw33v5goutput_value_g-nmnp0vey25o7input_value_g",
-      "source": "nmnp0xw33v5g",
-      "target": "nmnp0vey25o7",
-      "sourceHandle": "output_value_g",
-      "targetHandle": "input_value_g"
-    },
-    {
-      "id": "xy-edge__nmnp0xw33v5goutput_value_b-nmnp0vey25o7input_value_b",
-      "source": "nmnp0xw33v5g",
-      "target": "nmnp0vey25o7",
-      "sourceHandle": "output_value_b",
-      "targetHandle": "input_value_b"
-    },
-    {
       "id": "xy-edge__n4output_flow_do-nmnp19vq3i7jinput_flow_do",
       "source": "n4",
       "target": "nmnp19vq3i7j",
@@ -1655,18 +1397,32 @@
       "targetHandle": "input_flow_do"
     },
     {
-      "id": "xy-edge__nmnp19vq3i7joutput_flow_then-nmnnbfh7s6xjinput_flow_do",
-      "source": "nmnp19vq3i7j",
-      "target": "nmnnbfh7s6xj",
-      "sourceHandle": "output_flow_then",
-      "targetHandle": "input_flow_do"
+      "id": "xy-edge__nmnsbw4uxcvxoutput_flow_do-nmnncdpy7jkkinput_flow_check",
+      "source": "nmnsbw4uxcvx",
+      "target": "nmnncdpy7jkk",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
     },
     {
-      "id": "xy-edge__nmnp1abrkvxcoutput_value_value-nmnp195v0b2oinput_value_value",
-      "source": "nmnp1abrkvxc",
-      "target": "nmnp195v0b2o",
-      "sourceHandle": "output_value_value",
-      "targetHandle": "input_value_value"
+      "id": "xy-edge__nmnsbw1v4bsfoutput_flow_do-nmnncdpy7jkkinput_flow_check",
+      "source": "nmnsbw1v4bsf",
+      "target": "nmnncdpy7jkk",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__nmnp19vq3i7joutput_flow_then-n6input_flow_check",
+      "source": "nmnp19vq3i7j",
+      "target": "n6",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__nmnsbwpywakkoutput_flow_do-nmnp006skwrvinput_flow_check",
+      "source": "nmnsbwpywakk",
+      "target": "nmnp006skwrv",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
     }
   ],
   "macroDefs": [

--- a/public/models/Coagulation.gcaproj
+++ b/public/models/Coagulation.gcaproj
@@ -12,10 +12,10 @@
     "maxIterations": 1000,
     "tags": [
       "2-state",
-      "totalistic",
       "experimental",
       "customizable params",
-      "alternative neighborhoods"
+      "alternative neighborhoods",
+      "outer totalistic"
     ]
   },
   "attributes": [

--- a/public/models/Game Of Life.gcaproj
+++ b/public/models/Game Of Life.gcaproj
@@ -13,7 +13,7 @@
     "tags": [
       "classic",
       "2-state",
-      "totalistic"
+      "outer totalistic"
     ]
   },
   "attributes": [

--- a/src/help/HelpView.tsx
+++ b/src/help/HelpView.tsx
@@ -67,7 +67,7 @@ export function HelpView() {
 
         {/* ============================================================ */}
         <section id="help-fundamentals" className={styles.section}>
-          <h2 className={styles.h2}>The 6 Fundamentals of Cellular Automata</h2>
+          <h2 className={styles.h2}>The 6 Fundamentals of GenesisCA Cellular Automata</h2>
           <p className={styles.p}>
             Every GenesisCA model is built on these theoretical properties:
           </p>
@@ -127,11 +127,10 @@ export function HelpView() {
             per-cell (e.g., &quot;alive&quot;, &quot;age&quot;).{' '}
             <strong>Model Attributes</strong> are global parameters all cells can read
             but not write (e.g., &quot;birth threshold&quot;). Each attribute has a type
-            (bool, integer, float, tag, list, color), a default value, and a description.
+            (bool, integer, float, tag, color), a default value, and a description.
           </p>
           <ul className={styles.list}>
             <li><strong>Tag</strong> &mdash; An integer with named values (picklist). Define tag options in the editor, and use the Tag Constant node to reference them by name.</li>
-            <li><strong>List</strong> &mdash; A fixed-size array of elements of one basic type. Access elements via List Get Element and List Set Element nodes.</li>
             <li><strong>Color</strong> (model attributes only) &mdash; An RGB color value. Accessed via Get Model Attribute with separate R, G, B output ports. Adjustable live in the simulator.</li>
           </ul>
 
@@ -208,8 +207,21 @@ export function HelpView() {
         <section id="help-nodes" className={styles.section}>
           <h2 className={styles.h2}>Node Types Reference</h2>
           <p className={styles.p}>
-            GenesisCA provides 24 node types organized into categories:
+            GenesisCA provides 26 node types organized into categories:
           </p>
+
+          <h3 className={styles.h3}>
+            <span className={styles.nodeCategory} style={{ background: '#2e7d32' }}>Event</span>
+            Event Entry Points
+          </h3>
+          <table className={styles.table}>
+            <thead><tr><th>Node</th><th>Description</th></tr></thead>
+            <tbody>
+              <tr><td>Generation Step</td><td>Entry point for per-generation cell update logic. Connect &quot;DO&quot; to start the flow chain.</td></tr>
+              <tr><td>Input Mapping (C&rarr;A)</td><td>Entry point for Color-to-Attribute mapping (brush/image import). Outputs R, G, B values.</td></tr>
+              <tr><td>Output Mapping (A&rarr;C)</td><td>Entry point for Attribute-to-Color visualization. Runs as a separate sequential pass after the Generation Step, ensuring colors reflect the final cell state.</td></tr>
+            </tbody>
+          </table>
 
           <h3 className={styles.h3}>
             <span className={styles.nodeCategory} style={{ background: '#1b5e20' }}>Flow</span>
@@ -218,7 +230,6 @@ export function HelpView() {
           <table className={styles.table}>
             <thead><tr><th>Node</th><th>Description</th></tr></thead>
             <tbody>
-              <tr><td>Step</td><td>Entry point for per-generation logic. Connect &quot;DO&quot; to start the flow chain.</td></tr>
               <tr><td>Conditional</td><td>If/else branching based on a boolean condition.</td></tr>
               <tr><td>Sequence</td><td>Execute &quot;First&quot; then &quot;Then&quot; sequentially.</td></tr>
               <tr><td>Loop</td><td>Repeat &quot;Body&quot; a given number of times.</td></tr>
@@ -276,7 +287,7 @@ export function HelpView() {
               <tr><td>Set Attribute</td><td>Write a value to the current cell&apos;s attribute for the next generation.</td></tr>
               <tr><td>Set Neighborhood Attribute</td><td><strong>(Async only)</strong> Set a cell attribute for ALL cells in a neighborhood to a given value.</td></tr>
               <tr><td>Set Neighbor Attr By Index</td><td><strong>(Async only)</strong> Set a cell attribute for ONE specific neighbor (by index 0..N&minus;1) to a given value.</td></tr>
-              <tr><td>Get Neighbor Attr By Index</td><td><strong>(Async only)</strong> Read a cell attribute from ONE specific neighbor by index.</td></tr>
+              <tr><td>Get Neighbor Attr By Index</td><td>Read a cell attribute from ONE specific neighbor by index. Works in both sync and async modes.</td></tr>
             </tbody>
           </table>
 
@@ -287,7 +298,6 @@ export function HelpView() {
           <table className={styles.table}>
             <thead><tr><th>Node</th><th>Description</th></tr></thead>
             <tbody>
-              <tr><td>Input Color</td><td>Entry point for Color-to-Attribute mapping (brush/image import).</td></tr>
               <tr><td>Set Color Viewer</td><td>Write RGB values for an Attribute-to-Color visualization.</td></tr>
               <tr><td>Get Color Constant</td><td>Output fixed R, G, B values.</td></tr>
             </tbody>
@@ -351,7 +361,7 @@ export function HelpView() {
 
           <h3 className={styles.h3}>Async-Only Nodes</h3>
           <p className={styles.p}>
-            Three node types are exclusive to asynchronous mode. Using them in synchronous
+            Two node types are exclusive to asynchronous mode. Using them in synchronous
             mode will produce a compiler error.
           </p>
           <ul className={styles.ul}>
@@ -359,9 +369,11 @@ export function HelpView() {
               selected neighborhood.</li>
             <li><strong>Set Neighbor Attr By Index</strong> &mdash; Sets a cell attribute for one specific
               neighbor (by index 0..N&minus;1).</li>
-            <li><strong>Get Neighbor Attr By Index</strong> &mdash; Reads a cell attribute from one specific
-              neighbor by index.</li>
           </ul>
+          <p className={styles.p}>
+            <strong>Get Neighbor Attr By Index</strong> is a read-only node that works in both
+            sync and async modes, and is typically used alongside the async-only write nodes.
+          </p>
           <p className={styles.p}>
             <strong>Typical movement pattern:</strong> pick a random neighbor index &rarr;
             read that neighbor&apos;s attribute (Get Neighbor Attr By Index) &rarr;

--- a/src/help/HelpView.tsx
+++ b/src/help/HelpView.tsx
@@ -69,7 +69,7 @@ export function HelpView() {
         <section id="help-fundamentals" className={styles.section}>
           <h2 className={styles.h2}>The 6 Fundamentals of Cellular Automata</h2>
           <p className={styles.p}>
-            Every GenesisCA model satisfies these theoretical properties:
+            Every GenesisCA model is built on these theoretical properties:
           </p>
           <ol className={styles.list}>
             <li>
@@ -87,16 +87,20 @@ export function HelpView() {
               or custom patterns).
             </li>
             <li>
-              <strong>Self-modification only</strong> &mdash; A cell can only change its
-              own state, never the state of other cells.
+              <strong>Writability</strong> &mdash; In synchronous (classic) mode, a cell
+              can only modify its own attributes. In asynchronous mode, cells can also
+              directly modify the attributes of neighboring cells, enabling movement
+              and mass-conservation rules.
             </li>
             <li>
               <strong>Discrete space and time</strong> &mdash; Cells are arranged in a
               grid, and time advances in discrete generations.
             </li>
             <li>
-              <strong>Synchronous updates</strong> &mdash; All cells update their states
-              simultaneously each generation.
+              <strong>Synchronicity</strong> &mdash; The model can be either synchronous
+              (all cells update simultaneously each generation &mdash; classic CA) or
+              asynchronous (cells update sequentially, enabling number-conserving models).
+              See the <em>Asynchronous Mode</em> section below for details.
             </li>
           </ol>
         </section>
@@ -204,7 +208,7 @@ export function HelpView() {
         <section id="help-nodes" className={styles.section}>
           <h2 className={styles.h2}>Node Types Reference</h2>
           <p className={styles.p}>
-            GenesisCA provides 21 node types organized into categories:
+            GenesisCA provides 24 node types organized into categories:
           </p>
 
           <h3 className={styles.h3}>
@@ -270,6 +274,9 @@ export function HelpView() {
             <thead><tr><th>Node</th><th>Description</th></tr></thead>
             <tbody>
               <tr><td>Set Attribute</td><td>Write a value to the current cell&apos;s attribute for the next generation.</td></tr>
+              <tr><td>Set Neighborhood Attribute</td><td><strong>(Async only)</strong> Set a cell attribute for ALL cells in a neighborhood to a given value.</td></tr>
+              <tr><td>Set Neighbor Attr By Index</td><td><strong>(Async only)</strong> Set a cell attribute for ONE specific neighbor (by index 0..N&minus;1) to a given value.</td></tr>
+              <tr><td>Get Neighbor Attr By Index</td><td><strong>(Async only)</strong> Read a cell attribute from ONE specific neighbor by index.</td></tr>
             </tbody>
           </table>
 
@@ -314,6 +321,52 @@ export function HelpView() {
             Right-click a Macro node and choose &quot;Undo Macro&quot; to inline its
             contents back into the parent graph. All restored nodes are automatically
             selected for easy repositioning.
+          </p>
+        </section>
+
+        {/* ============================================================ */}
+        <section id="help-async" className={styles.section}>
+          <h2 className={styles.h2}>Asynchronous Mode</h2>
+          <p className={styles.p}>
+            As described in the <em>Synchronicity</em> fundamental, GenesisCA supports
+            both synchronous (classic) and asynchronous update modes.
+          </p>
+          <p className={styles.p}>
+            <strong>Asynchronous mode</strong> (set in Model Properties &gt; Execution) updates
+            cells one at a time using a single buffer, so each cell sees previous
+            updates within the same generation. Combined with the expanded <em>Writability</em> rules
+            (cells can modify neighbor attributes directly), this enables <em>number-conserving</em> models
+            where elements move across the grid without being created or destroyed.
+          </p>
+
+          <h3 className={styles.h3}>Update Schemes</h3>
+          <ul className={styles.ul}>
+            <li><strong>Random Order</strong> &mdash; Every cell updates exactly once per generation in a
+              random permutation (Fisher-Yates shuffle).</li>
+            <li><strong>Random Independent</strong> &mdash; N random cell picks with replacement per generation.
+              Some cells may update 0 or 2+ times.</li>
+            <li><strong>Cyclic</strong> &mdash; A fixed random order decided at initialization, reused every
+              generation. Fastest option with zero per-step shuffle cost.</li>
+          </ul>
+
+          <h3 className={styles.h3}>Async-Only Nodes</h3>
+          <p className={styles.p}>
+            Three node types are exclusive to asynchronous mode. Using them in synchronous
+            mode will produce a compiler error.
+          </p>
+          <ul className={styles.ul}>
+            <li><strong>Set Neighborhood Attribute</strong> &mdash; Sets a cell attribute for all cells in a
+              selected neighborhood.</li>
+            <li><strong>Set Neighbor Attr By Index</strong> &mdash; Sets a cell attribute for one specific
+              neighbor (by index 0..N&minus;1).</li>
+            <li><strong>Get Neighbor Attr By Index</strong> &mdash; Reads a cell attribute from one specific
+              neighbor by index.</li>
+          </ul>
+          <p className={styles.p}>
+            <strong>Typical movement pattern:</strong> pick a random neighbor index &rarr;
+            read that neighbor&apos;s attribute (Get Neighbor Attr By Index) &rarr;
+            if empty, set that neighbor (Set Neighbor Attr By Index) and clear self
+            (Set Attribute).
           </p>
         </section>
 

--- a/src/model/ModelContext.tsx
+++ b/src/model/ModelContext.tsx
@@ -269,8 +269,21 @@ function modelReducer(state: ModelState, action: ModelAction): ModelState {
     case 'NEW_MODEL':
       return { model: EMPTY_MODEL, isDirty: false, modelVersion: state.modelVersion + 1 };
 
-    case 'LOAD_MODEL':
-      return { model: action.model, isDirty: false, modelVersion: state.modelVersion + 1 };
+    case 'LOAD_MODEL': {
+      const m = action.model;
+      // Migration guards for loaded files (same as localStorage)
+      if (!m.graphNodes) m.graphNodes = [];
+      if (!m.graphEdges) m.graphEdges = [];
+      if (!m.macroDefs) m.macroDefs = [];
+      if (!m.properties.tags) m.properties.tags = [];
+      if (!m.properties.updateMode) m.properties.updateMode = 'synchronous';
+      if (!m.properties.asyncScheme) m.properties.asyncScheme = 'random-order';
+      for (const n of m.neighborhoods) { n.margin ??= 2; }
+      for (const a of m.attributes) {
+        if (a.type === 'tag' && !a.tagOptions) a.tagOptions = [];
+      }
+      return { model: m, isDirty: false, modelVersion: state.modelVersion + 1 };
+    }
 
     case 'MARK_SAVED':
       return { ...state, isDirty: false };
@@ -322,6 +335,8 @@ function createInitialState(): ModelState {
         if (!model.graphEdges) model.graphEdges = [];
         if (!model.macroDefs) model.macroDefs = [];
         if (!model.properties.tags) model.properties.tags = [];
+        if (!model.properties.updateMode) model.properties.updateMode = 'synchronous';
+        if (!model.properties.asyncScheme) model.properties.asyncScheme = 'random-order';
         for (const n of model.neighborhoods) { n.margin ??= 2; }
         for (const a of model.attributes) {
           if (a.type === 'tag' && !a.tagOptions) a.tagOptions = [];

--- a/src/model/defaultModel.ts
+++ b/src/model/defaultModel.ts
@@ -11,6 +11,8 @@ export const EMPTY_MODEL: CAModel = {
     description: '',
     topology: '2d-grid',
     boundaryTreatment: 'torus',
+    updateMode: 'synchronous',
+    asyncScheme: 'random-order',
     gridWidth: 100,
     gridHeight: 100,
     maxIterations: 1000,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -35,6 +35,8 @@ export interface Mapping {
 
 export type BoundaryTreatment = 'constant' | 'torus';
 export type Topology = '2d-grid';
+export type UpdateMode = 'synchronous' | 'asynchronous';
+export type AsyncScheme = 'random-order' | 'random-independent' | 'cyclic';
 
 /** Top-level model properties */
 export interface ModelProperties {
@@ -44,6 +46,8 @@ export interface ModelProperties {
   description: string;
   topology: Topology;
   boundaryTreatment: BoundaryTreatment;
+  updateMode: UpdateMode;
+  asyncScheme: AsyncScheme;
   gridWidth: number;
   gridHeight: number;
   maxIterations: number;

--- a/src/modeler/panels/PropertiesPanelContent.tsx
+++ b/src/modeler/panels/PropertiesPanelContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useModel } from '../../model/ModelContext';
-import type { BoundaryTreatment } from '../../model/types';
+import type { BoundaryTreatment, UpdateMode, AsyncScheme } from '../../model/types';
 import styles from './PanelContent.module.css';
 
 export function PropertiesPanelContent() {
@@ -145,9 +145,74 @@ export function PropertiesPanelContent() {
         </div>
       </div>
 
-      {/* Max Iterations and Model Attribute Defaults removed:
-         - Max Iterations is not enforced by the simulator
-         - Model Attribute defaults are set in the Attributes panel */}
+      <div className={styles.section}>
+        <div className={styles.sectionTitle}>Execution</div>
+        <div className={styles.fieldGroup}>
+          <div className={styles.field}>
+            <label className={styles.fieldLabel}>Update Mode</label>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 2 }}>
+              <label style={{ display: 'flex', alignItems: 'flex-start', gap: 6, cursor: 'pointer', fontSize: '0.72rem' }}>
+                <input
+                  type="radio"
+                  name="updateMode"
+                  value="synchronous"
+                  checked={properties.updateMode !== 'asynchronous'}
+                  onChange={() => updateProperties({ updateMode: 'synchronous' as UpdateMode })}
+                  style={{ marginTop: 2 }}
+                />
+                <span>
+                  <strong>Synchronous</strong>
+                  <br />
+                  <span style={{ color: '#888', fontSize: '0.66rem' }}>
+                    All cells read from the previous generation and write to the next simultaneously. Classic CA behavior.
+                  </span>
+                </span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'flex-start', gap: 6, cursor: 'pointer', fontSize: '0.72rem' }}>
+                <input
+                  type="radio"
+                  name="updateMode"
+                  value="asynchronous"
+                  checked={properties.updateMode === 'asynchronous'}
+                  onChange={() => updateProperties({ updateMode: 'asynchronous' as UpdateMode })}
+                  style={{ marginTop: 2 }}
+                />
+                <span>
+                  <strong>Asynchronous</strong>
+                  <br />
+                  <span style={{ color: '#888', fontSize: '0.66rem' }}>
+                    Cells update one at a time using a single buffer. Each cell sees previous updates within the same generation. Enables number-conserving models.
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
+          {properties.updateMode === 'asynchronous' && (
+            <div className={styles.field}>
+              <label className={styles.fieldLabel}>Asynchronous Update Scheme</label>
+              <select
+                className={styles.selectInput}
+                value={properties.asyncScheme || 'random-order'}
+                onChange={e =>
+                  updateProperties({ asyncScheme: e.target.value as AsyncScheme })
+                }
+              >
+                <option value="random-order">Random Order</option>
+                <option value="random-independent">Random Independent</option>
+                <option value="cyclic">Cyclic</option>
+              </select>
+              <span style={{ color: '#888', fontSize: '0.62rem', marginTop: 2, display: 'block' }}>
+                {(properties.asyncScheme || 'random-order') === 'random-order' &&
+                  'All cells update once per generation in random order (Fisher-Yates shuffle).'}
+                {properties.asyncScheme === 'random-independent' &&
+                  'N random cell picks with replacement per generation. Some cells may update 0 or 2+ times.'}
+                {properties.asyncScheme === 'cyclic' &&
+                  'A fixed random order decided at initialization, reused every generation. Fastest option.'}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -240,6 +240,12 @@ function CaNodeComponent({ id, data }: NodeProps) {
     } else if (nodeData.nodeType === 'setColorViewer') {
       const mapping = model.mappings.find(m => m.id === nodeData.config.mappingId);
       collapsedLabel = mapping ? `Set A\u2192C - ${mapping.name}` : def.label;
+    } else if (nodeData.nodeType === 'inputColor') {
+      const mapping = model.mappings.find(m => m.id === nodeData.config.mappingId);
+      collapsedLabel = mapping ? `C\u2192A: ${mapping.name}` : def.label;
+    } else if (nodeData.nodeType === 'outputMapping') {
+      const mapping = model.mappings.find(m => m.id === nodeData.config.mappingId);
+      collapsedLabel = mapping ? `A\u2192C: ${mapping.name}` : def.label;
     } else {
       collapsedLabel = def.label;
     }
@@ -538,6 +544,21 @@ function CaNodeComponent({ id, data }: NodeProps) {
             <option value="">Select Mapping...</option>
             {model.mappings
               .filter(m => !m.isAttributeToColor)
+              .map(m => (
+                <option key={m.id} value={m.id}>{m.name}</option>
+              ))}
+          </select>
+        )}
+
+        {nodeData.nodeType === 'outputMapping' && (
+          <select
+            className={styles.select}
+            value={(nodeData.config.mappingId as string) || ''}
+            onChange={e => updateConfig('mappingId', e.target.value)}
+          >
+            <option value="">Select Mapping...</option>
+            {model.mappings
+              .filter(m => m.isAttributeToColor)
               .map(m => (
                 <option key={m.id} value={m.id}>{m.name}</option>
               ))}

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -229,10 +229,14 @@ function CaNodeComponent({ id, data }: NodeProps) {
     } else if (nodeData.nodeType === 'setAttribute') {
       const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
       collapsedLabel = attr ? `Set - ${attr.name}` : def.label;
-    } else if (nodeData.nodeType === 'getNeighborsAttribute') {
+    } else if (nodeData.nodeType === 'getNeighborsAttribute' || nodeData.nodeType === 'getNeighborAttributeByIndex') {
       const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
       const nbr = model.neighborhoods.find(n => n.id === nodeData.config.neighborhoodId);
       collapsedLabel = attr && nbr ? `${nbr.name}[${attr.name}]` : def.label;
+    } else if (nodeData.nodeType === 'setNeighborhoodAttribute' || nodeData.nodeType === 'setNeighborAttributeByIndex') {
+      const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
+      const nbr = model.neighborhoods.find(n => n.id === nodeData.config.neighborhoodId);
+      collapsedLabel = attr && nbr ? `Set ${nbr.name}[${attr.name}]` : def.label;
     } else if (nodeData.nodeType === 'setColorViewer') {
       const mapping = model.mappings.find(m => m.id === nodeData.config.mappingId);
       collapsedLabel = mapping ? `Set A\u2192C - ${mapping.name}` : def.label;
@@ -329,7 +333,10 @@ function CaNodeComponent({ id, data }: NodeProps) {
           </select>
         )}
 
-        {nodeData.nodeType === 'getNeighborsAttribute' && (
+        {(nodeData.nodeType === 'getNeighborsAttribute'
+          || nodeData.nodeType === 'getNeighborAttributeByIndex'
+          || nodeData.nodeType === 'setNeighborhoodAttribute'
+          || nodeData.nodeType === 'setNeighborAttributeByIndex') && (
           <>
             <select
               className={styles.select}
@@ -776,7 +783,7 @@ function CaNodeComponent({ id, data }: NodeProps) {
         let effectiveWidget = portDef.inlineWidget;
         const setAttrId = nodeData.config.attributeId as string;
         const setAttr = setAttrId ? model.attributes.find(a => a.id === setAttrId) : undefined;
-        if (effectiveWidget && (nodeData.nodeType === 'setAttribute') && port.id === 'value') {
+        if (effectiveWidget && (nodeData.nodeType === 'setAttribute' || nodeData.nodeType === 'setNeighborhoodAttribute' || nodeData.nodeType === 'setNeighborAttributeByIndex') && port.id === 'value') {
           const attr = setAttr;
           if (!attr) {
             effectiveWidget = undefined;

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -697,6 +697,7 @@ function buildLoopParams(model: CAModel): {
   cellAttrs: Array<{ id: string; type: string }>;
   neighborhoods: Array<{ id: string }>;
 } {
+  const isAsync = model.properties.updateMode === 'asynchronous';
   const cellAttrs = model.attributes
     .filter(a => !a.isModelAttribute)
     .map(a => ({ id: a.id, type: a.type }));
@@ -707,6 +708,7 @@ function buildLoopParams(model: CAModel): {
   for (const a of cellAttrs) parts.push(`w_${a.id}`);
   for (const n of neighborhoods) { parts.push(`nIdx_${n.id}`); parts.push(`nSz_${n.id}`); }
   parts.push('modelAttrs', 'colors', 'activeViewer');
+  if (isAsync) parts.push('order');
 
   return { params: parts.join(', '), cellAttrs, neighborhoods };
 }
@@ -746,12 +748,30 @@ export function compileGraph(
     return { stepCode: '', inputColorCodes: [], error: 'Model required for SoA compilation.' };
   }
 
+  const isAsync = model.properties.updateMode === 'asynchronous';
+
+  // --- Validate async-only nodes in sync mode ---
+  const ASYNC_ONLY_TYPES = new Set(['setNeighborhoodAttribute', 'setNeighborAttributeByIndex', 'getNeighborAttributeByIndex']);
+  let asyncValidationError: string | undefined;
+  if (!isAsync) {
+    const offending = graphNodes.find(n => ASYNC_ONLY_TYPES.has(n.data.nodeType));
+    if (offending) {
+      const label = offending.data.nodeType === 'setNeighborhoodAttribute' ? 'Set Neighborhood Attribute'
+        : offending.data.nodeType === 'setNeighborAttributeByIndex' ? 'Set Neighbor Attr By Index'
+        : 'Get Neighbor Attr By Index';
+      asyncValidationError = `Node "${label}" requires Asynchronous update mode. Change in Model Properties > Execution.`;
+    }
+  }
+
   const { nodeMap, inputToSource, flowOutputToTargets } = buildAdjacency(graphNodes, graphEdges);
   const { params: loopParams, cellAttrs } = buildLoopParams(model);
   const cellParams = buildCellParams(model);
 
   // Generate attribute copy lines (previous → next generation)
-  const copyLines = cellAttrs.map(a => `      w_${a.id}[idx] = r_${a.id}[idx];`);
+  // In async mode, r_ and w_ are the same buffer so copy lines are skipped
+  const copyLines = isAsync
+    ? []
+    : cellAttrs.map(a => `      w_${a.id}[idx] = r_${a.id}[idx];`);
 
   // --- Compile Step function (loop-wrapped) ---
   const stepNode = graphNodes.find(n => n.data.nodeType === 'step');
@@ -766,18 +786,36 @@ export function compileGraph(
       s => `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`,
     );
 
-    stepCode = [
-      `(function(${loopParams}) {`,
-      ...scratchDecls,
-      '  for (let idx = 0; idx < total; idx++) {',
-      '    const colorIdx = idx * 4;',
-      ...copyLines,
-      ...valueLines,
-      '',
-      ...flowLines,
-      '  }',
-      '})',
-    ].join('\n');
+    if (isAsync) {
+      // Async mode: iterate cells via shuffled order array
+      stepCode = [
+        `(function(${loopParams}) {`,
+        ...scratchDecls,
+        '  for (let _i = 0; _i < total; _i++) {',
+        '    const idx = order[_i];',
+        '    const colorIdx = idx * 4;',
+        ...copyLines,
+        ...valueLines,
+        '',
+        ...flowLines,
+        '  }',
+        '})',
+      ].join('\n');
+    } else {
+      // Sync mode: sequential iteration (unchanged)
+      stepCode = [
+        `(function(${loopParams}) {`,
+        ...scratchDecls,
+        '  for (let idx = 0; idx < total; idx++) {',
+        '    const colorIdx = idx * 4;',
+        ...copyLines,
+        ...valueLines,
+        '',
+        ...flowLines,
+        '  }',
+        '})',
+      ].join('\n');
+    }
   }
 
   // --- Compile InputColor functions (per-cell, not loop-wrapped) ---
@@ -805,7 +843,8 @@ export function compileGraph(
     inputColorCodes.push({ mappingId, code });
   }
 
-  const error = !stepNode ? 'No Step node found. Add a Step node as the entry point.' : undefined;
+  const error = asyncValidationError
+    ?? (!stepNode ? 'No Step node found. Add a Step node as the entry point.' : undefined);
 
   return { stepCode, inputColorCodes, error };
 }

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -732,6 +732,7 @@ function buildCellParams(model: CAModel): string {
 export interface CompileResult {
   stepCode: string;
   inputColorCodes: Array<{ mappingId: string; code: string }>;
+  outputMappingCodes: Array<{ mappingId: string; code: string }>;
   error?: string;
 }
 
@@ -741,24 +742,24 @@ export function compileGraph(
   model?: CAModel,
 ): CompileResult {
   if (graphNodes.length === 0) {
-    return { stepCode: '', inputColorCodes: [], error: 'No nodes in graph.' };
+    return { stepCode: '', inputColorCodes: [], outputMappingCodes: [], error: 'No nodes in graph.' };
   }
 
   if (!model) {
-    return { stepCode: '', inputColorCodes: [], error: 'Model required for SoA compilation.' };
+    return { stepCode: '', inputColorCodes: [], outputMappingCodes: [], error: 'Model required for SoA compilation.' };
   }
 
   const isAsync = model.properties.updateMode === 'asynchronous';
 
   // --- Validate async-only nodes in sync mode ---
-  const ASYNC_ONLY_TYPES = new Set(['setNeighborhoodAttribute', 'setNeighborAttributeByIndex', 'getNeighborAttributeByIndex']);
+  // getNeighborAttributeByIndex is read-only so it works in both sync and async modes
+  const ASYNC_ONLY_TYPES = new Set(['setNeighborhoodAttribute', 'setNeighborAttributeByIndex']);
   let asyncValidationError: string | undefined;
   if (!isAsync) {
     const offending = graphNodes.find(n => ASYNC_ONLY_TYPES.has(n.data.nodeType));
     if (offending) {
-      const label = offending.data.nodeType === 'setNeighborhoodAttribute' ? 'Set Neighborhood Attribute'
-        : offending.data.nodeType === 'setNeighborAttributeByIndex' ? 'Set Neighbor Attr By Index'
-        : 'Get Neighbor Attr By Index';
+      const label = offending.data.nodeType === 'setNeighborhoodAttribute'
+        ? 'Set Neighborhood Attribute' : 'Set Neighbor Attr By Index';
       asyncValidationError = `Node "${label}" requires Asynchronous update mode. Change in Model Properties > Execution.`;
     }
   }
@@ -843,10 +844,45 @@ export function compileGraph(
     inputColorCodes.push({ mappingId, code });
   }
 
+  // --- Compile Output Mapping functions (loop-wrapped, always sequential, no copy lines) ---
+  const outputMappingNodes = graphNodes.filter(n => n.data.nodeType === 'outputMapping');
+  const outputMappingCodes: Array<{ mappingId: string; code: string }> = [];
+
+  // Output mapping uses sync-style loop params (no order) regardless of updateMode
+  const omParamParts: string[] = ['total'];
+  for (const a of cellAttrs) omParamParts.push(`r_${a.id}`);
+  for (const a of cellAttrs) omParamParts.push(`w_${a.id}`);
+  const neighborhoods = model.neighborhoods.map(n => ({ id: n.id }));
+  for (const n of neighborhoods) { omParamParts.push(`nIdx_${n.id}`); omParamParts.push(`nSz_${n.id}`); }
+  omParamParts.push('modelAttrs', 'colors', 'activeViewer');
+  const omParams = omParamParts.join(', ');
+
+  for (const omNode of outputMappingNodes) {
+    const mappingId = omNode.data.config.mappingId as string || '';
+    const { valueLines, flowLines, scratchNodes } = compileRoot(
+      omNode, 'do', nodeMap, inputToSource, flowOutputToTargets, model,
+    );
+    const scratchDecls = scratchNodes.map(
+      s => `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`,
+    );
+    const code = [
+      `(function(${omParams}) {`,
+      ...scratchDecls,
+      '  for (let idx = 0; idx < total; idx++) {',
+      '    const colorIdx = idx * 4;',
+      ...valueLines,
+      '',
+      ...flowLines,
+      '  }',
+      '})',
+    ].join('\n');
+    outputMappingCodes.push({ mappingId, code });
+  }
+
   const error = asyncValidationError
     ?? (!stepNode ? 'No Step node found. Add a Step node as the entry point.' : undefined);
 
-  return { stepCode, inputColorCodes, error };
+  return { stepCode, inputColorCodes, outputMappingCodes, error };
 }
 
 /**
@@ -861,6 +897,7 @@ export function compileAndBuild(
   inputColorFns: Array<{ mappingId: string; fn: Function }>;
   stepCode: string;
   inputColorCodes: Array<{ mappingId: string; code: string }>;
+  outputMappingCodes: Array<{ mappingId: string; code: string }>;
   error?: string;
 } {
   const result = compileGraph(graphNodes, graphEdges, model);
@@ -874,6 +911,7 @@ export function compileAndBuild(
       return {
         stepFn: null, inputColorFns: [],
         stepCode: result.stepCode, inputColorCodes: result.inputColorCodes,
+        outputMappingCodes: result.outputMappingCodes,
         error: `Step compilation error: ${e instanceof Error ? e.message : String(e)}`,
       };
     }
@@ -889,10 +927,15 @@ export function compileAndBuild(
       return {
         stepFn: null, inputColorFns: [],
         stepCode: result.stepCode, inputColorCodes: result.inputColorCodes,
+        outputMappingCodes: result.outputMappingCodes,
         error: `InputColor compilation error: ${e instanceof Error ? e.message : String(e)}`,
       };
     }
   }
 
-  return { stepFn, inputColorFns, stepCode: result.stepCode, inputColorCodes: result.inputColorCodes, error: result.error };
+  return {
+    stepFn, inputColorFns,
+    stepCode: result.stepCode, inputColorCodes: result.inputColorCodes,
+    outputMappingCodes: result.outputMappingCodes, error: result.error,
+  };
 }

--- a/src/modeler/vpl/nodes/GetNeighborAttributeByIndexNode.ts
+++ b/src/modeler/vpl/nodes/GetNeighborAttributeByIndexNode.ts
@@ -1,0 +1,19 @@
+import type { NodeTypeDef } from '../types';
+
+export const GetNeighborAttributeByIndexNode: NodeTypeDef = {
+  type: 'getNeighborAttributeByIndex',
+  label: 'Get Neighbor Attr By Index',
+  category: 'data',
+  color: '#b71c1c',
+  ports: [
+    { id: 'index', label: 'Index', kind: 'input', category: 'value', dataType: 'integer', inlineWidget: 'number', defaultValue: '0' },
+    { id: 'value', label: 'Value', kind: 'output', category: 'value', dataType: 'any' },
+  ],
+  defaultConfig: { neighborhoodId: '', attributeId: '' },
+  compile: (nodeId, config, inputs) => {
+    const nbrId = config.neighborhoodId as string || '_undef';
+    const attr = config.attributeId as string || '_undef';
+    const index = inputs['index'] || '0';
+    return `const _v${nodeId} = r_${attr}[nIdx_${nbrId}[idx * nSz_${nbrId} + ((${index}) | 0)]];\n`;
+  },
+};

--- a/src/modeler/vpl/nodes/InputColorNode.ts
+++ b/src/modeler/vpl/nodes/InputColorNode.ts
@@ -2,9 +2,9 @@ import type { NodeTypeDef } from '../types';
 
 export const InputColorNode: NodeTypeDef = {
   type: 'inputColor',
-  label: 'Input Color',
-  category: 'color',
-  color: '#006064',
+  label: 'Input Mapping (C\u2192A)',
+  category: 'event',
+  color: '#2e7d32',
   ports: [
     { id: 'do', label: 'DO', kind: 'output', category: 'flow' },
     { id: 'r', label: 'R', kind: 'output', category: 'value', dataType: 'integer' },

--- a/src/modeler/vpl/nodes/OutputMappingNode.ts
+++ b/src/modeler/vpl/nodes/OutputMappingNode.ts
@@ -1,0 +1,13 @@
+import type { NodeTypeDef } from '../types';
+
+export const OutputMappingNode: NodeTypeDef = {
+  type: 'outputMapping',
+  label: 'Output Mapping (A\u2192C)',
+  category: 'event',
+  color: '#2e7d32',
+  ports: [
+    { id: 'do', label: 'DO', kind: 'output', category: 'flow' },
+  ],
+  defaultConfig: { mappingId: '' },
+  compile: () => '', // Root node — compiler handles it specially
+};

--- a/src/modeler/vpl/nodes/SetNeighborAttributeByIndexNode.ts
+++ b/src/modeler/vpl/nodes/SetNeighborAttributeByIndexNode.ts
@@ -1,0 +1,24 @@
+import type { NodeTypeDef } from '../types';
+
+export const SetNeighborAttributeByIndexNode: NodeTypeDef = {
+  type: 'setNeighborAttributeByIndex',
+  label: 'Set Neighbor Attr By Index',
+  category: 'output',
+  color: '#4a148c',
+  ports: [
+    { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
+    { id: 'index', label: 'Index', kind: 'input', category: 'value', dataType: 'integer', inlineWidget: 'number', defaultValue: '0' },
+    { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
+  ],
+  defaultConfig: { neighborhoodId: '', attributeId: '' },
+  compile: (nodeId, config, inputs) => {
+    const nbrId = config.neighborhoodId as string || '_undef';
+    const attr = config.attributeId as string || '_undef';
+    const index = inputs['index'] || '0';
+    const value = inputs['value'] || '0';
+    return [
+      `const _ni${nodeId} = nIdx_${nbrId}[idx * nSz_${nbrId} + ((${index}) | 0)];`,
+      `if (_ni${nodeId} < total) w_${attr}[_ni${nodeId}] = ${value};`,
+    ].join(' ') + '\n';
+  },
+};

--- a/src/modeler/vpl/nodes/SetNeighborhoodAttributeNode.ts
+++ b/src/modeler/vpl/nodes/SetNeighborhoodAttributeNode.ts
@@ -1,0 +1,25 @@
+import type { NodeTypeDef } from '../types';
+
+export const SetNeighborhoodAttributeNode: NodeTypeDef = {
+  type: 'setNeighborhoodAttribute',
+  label: 'Set Neighborhood Attribute',
+  category: 'output',
+  color: '#4a148c',
+  ports: [
+    { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
+    { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
+  ],
+  defaultConfig: { neighborhoodId: '', attributeId: '' },
+  compile: (nodeId, config, inputs) => {
+    const nbrId = config.neighborhoodId as string || '_undef';
+    const attr = config.attributeId as string || '_undef';
+    const value = inputs['value'] || '0';
+    return [
+      `const _nb${nodeId} = idx * nSz_${nbrId};`,
+      `for (let _n${nodeId} = 0; _n${nodeId} < nSz_${nbrId}; _n${nodeId}++) {`,
+      `  const _ni${nodeId} = nIdx_${nbrId}[_nb${nodeId} + _n${nodeId}];`,
+      `  if (_ni${nodeId} < total) w_${attr}[_ni${nodeId}] = ${value};`,
+      `}`,
+    ].join(' ') + '\n';
+  },
+};

--- a/src/modeler/vpl/nodes/StepNode.ts
+++ b/src/modeler/vpl/nodes/StepNode.ts
@@ -2,9 +2,9 @@ import type { NodeTypeDef } from '../types';
 
 export const StepNode: NodeTypeDef = {
   type: 'step',
-  label: 'Step',
-  category: 'flow',
-  color: '#1b5e20',
+  label: 'Generation Step',
+  category: 'event',
+  color: '#2e7d32',
   ports: [
     { id: 'do', label: 'DO', kind: 'output', category: 'flow' },
   ],

--- a/src/modeler/vpl/nodes/registry.ts
+++ b/src/modeler/vpl/nodes/registry.ts
@@ -25,10 +25,14 @@ import { TagConstantNode } from './TagConstantNode';
 import { SetNeighborhoodAttributeNode } from './SetNeighborhoodAttributeNode';
 import { GetNeighborAttributeByIndexNode } from './GetNeighborAttributeByIndexNode';
 import { SetNeighborAttributeByIndexNode } from './SetNeighborAttributeByIndexNode';
+import { OutputMappingNode } from './OutputMappingNode';
 
 const ALL_NODES: NodeTypeDef[] = [
-  // Flow
+  // Event (entry points)
   StepNode,
+  InputColorNode,
+  OutputMappingNode,
+  // Flow
   ConditionalNode,
   SequenceNode,
   LoopNode,
@@ -53,7 +57,6 @@ const ALL_NODES: NodeTypeDef[] = [
   SetNeighborhoodAttributeNode,
   SetNeighborAttributeByIndexNode,
   // Color
-  InputColorNode,
   SetColorViewerNode,
   GetColorConstantNode,
   // Macro

--- a/src/modeler/vpl/nodes/registry.ts
+++ b/src/modeler/vpl/nodes/registry.ts
@@ -22,6 +22,9 @@ import { MacroNode } from './MacroNode';
 import { MacroInputNode } from './MacroInputNode';
 import { MacroOutputNode } from './MacroOutputNode';
 import { TagConstantNode } from './TagConstantNode';
+import { SetNeighborhoodAttributeNode } from './SetNeighborhoodAttributeNode';
+import { GetNeighborAttributeByIndexNode } from './GetNeighborAttributeByIndexNode';
+import { SetNeighborAttributeByIndexNode } from './SetNeighborAttributeByIndexNode';
 
 const ALL_NODES: NodeTypeDef[] = [
   // Flow
@@ -33,6 +36,7 @@ const ALL_NODES: NodeTypeDef[] = [
   GetCellAttributeNode,
   GetModelAttributeNode,
   GetNeighborsAttributeNode,
+  GetNeighborAttributeByIndexNode,
   GetConstantNode,
   GetRandomNode,
   TagConstantNode,
@@ -46,6 +50,8 @@ const ALL_NODES: NodeTypeDef[] = [
   GroupOperatorNode,
   // Output
   SetAttributeNode,
+  SetNeighborhoodAttributeNode,
+  SetNeighborAttributeByIndexNode,
   // Color
   InputColorNode,
   SetColorViewerNode,

--- a/src/modeler/vpl/types.ts
+++ b/src/modeler/vpl/types.ts
@@ -30,7 +30,7 @@ export interface NodeConfig {
 export interface NodeTypeDef {
   type: string;
   label: string;
-  category: 'data' | 'logic' | 'aggregation' | 'flow' | 'output' | 'color';
+  category: 'event' | 'data' | 'logic' | 'aggregation' | 'flow' | 'output' | 'color';
   color: string;
   ports: PortDef[];
   defaultConfig: NodeConfig;

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -190,6 +190,7 @@ export function SimulatorView() {
       type: 'step',
       count: gensPerFrameRef.current,
       activeViewer: activeViewerRef.current,
+      skipColorPass: unlimitedGensRef.current,
     });
   }, []);
 
@@ -332,6 +333,7 @@ export function SimulatorView() {
       asyncScheme: model.properties.asyncScheme || 'random-order',
       stepCode: result.stepCode,
       inputColorCodes: result.inputColorCodes,
+      outputMappingCodes: result.outputMappingCodes,
       activeViewer: viewer,
     });
     workerRef.current = worker;

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -328,6 +328,8 @@ export function SimulatorView() {
       })),
       neighborhoods: model.neighborhoods.map(n => ({ id: n.id, coords: n.coords })),
       boundaryTreatment: model.properties.boundaryTreatment,
+      updateMode: model.properties.updateMode || 'synchronous',
+      asyncScheme: model.properties.asyncScheme || 'random-order',
       stepCode: result.stepCode,
       inputColorCodes: result.inputColorCodes,
       activeViewer: viewer,

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -24,6 +24,8 @@ interface InitMsg {
   attributes: AttrDef[];
   neighborhoods: NeighborhoodDef[];
   boundaryTreatment: string;
+  updateMode: string;
+  asyncScheme: string;
   stepCode: string;
   inputColorCodes: Array<{ mappingId: string; code: string }>;
   activeViewer: string;
@@ -38,7 +40,7 @@ interface PaintMsg {
 }
 interface RandomizeMsg { type: 'randomize'; activeViewer: string }
 interface ResetMsg { type: 'reset'; activeViewer: string }
-interface RecompileMsg { type: 'recompile'; stepCode: string; inputColorCodes: Array<{ mappingId: string; code: string }> }
+interface RecompileMsg { type: 'recompile'; stepCode: string; inputColorCodes: Array<{ mappingId: string; code: string }>; updateMode: string; asyncScheme: string }
 interface UpdateModelAttrsMsg { type: 'updateModelAttrs'; attrs: Record<string, number> }
 interface ImportImageMsg { type: 'importImage'; pixels: Uint8ClampedArray; mappingId: string; activeViewer: string }
 
@@ -54,6 +56,8 @@ let total = 0;
 let cellAttrs: AttrDef[] = [];
 let neighborhoods: NeighborhoodDef[] = [];
 let boundaryTreatment = 'torus';
+let updateMode = 'synchronous';
+let asyncScheme = 'random-order';
 let generation = 0;
 
 // SoA: one typed array per attribute, double-buffered (A = read, B = write)
@@ -66,6 +70,7 @@ let writeAttrs = attrsB;
 let nbrIndices: Record<string, Int32Array> = {};
 
 let colors: Uint8ClampedArray = new Uint8ClampedArray(0);
+let orderArray: Int32Array | null = null;
 let stepFn: Function | null = null;
 let inputColorFns: Array<{ mappingId: string; fn: Function }> = [];
 
@@ -104,20 +109,43 @@ function initGrid(): void {
   total = width * height;
   attrsA = {};
   attrsB = {};
+  const isAsync = updateMode === 'asynchronous';
 
   for (const attr of cellAttrs) {
     const arrA = createTypedArray(attr.type, total);
-    const arrB = createTypedArray(attr.type, total);
     const dv = defaultValue(attr);
-    if (dv !== 0) { arrA.fill(dv); arrB.fill(dv); }
+    if (dv !== 0) arrA.fill(dv);
     attrsA[attr.id] = arrA;
-    attrsB[attr.id] = arrB;
+
+    if (isAsync) {
+      // Async: single buffer — both read and write point to the same arrays
+      attrsB[attr.id] = arrA;
+    } else {
+      const arrB = createTypedArray(attr.type, total);
+      if (dv !== 0) arrB.fill(dv);
+      attrsB[attr.id] = arrB;
+    }
   }
 
   readAttrs = attrsA;
-  writeAttrs = attrsB;
+  writeAttrs = isAsync ? attrsA : attrsB;
   colors = new Uint8ClampedArray(total * 4);
   generation = 0;
+
+  // Order array for async mode
+  if (isAsync) {
+    orderArray = new Int32Array(total);
+    for (let i = 0; i < total; i++) orderArray[i] = i;
+    // For cyclic scheme, shuffle once at init and reuse
+    if (asyncScheme === 'cyclic') {
+      for (let i = total - 1; i > 0; i--) {
+        const j = (Math.random() * (i + 1)) | 0;
+        const tmp = orderArray[i]!; orderArray[i] = orderArray[j]!; orderArray[j] = tmp;
+      }
+    }
+  } else {
+    orderArray = null;
+  }
 }
 
 function buildNeighborIndices(): void {
@@ -157,21 +185,28 @@ function buildNeighborIndices(): void {
 
   // For constant boundary: ensure read attrs have a sentinel cell at index `total`
   // We extend each array by 1 with the default value
+  const isAsync = updateMode === 'asynchronous';
   if (boundaryTreatment !== 'torus') {
     for (const attr of cellAttrs) {
       const oldA = attrsA[attr.id]!;
-      const oldB = attrsB[attr.id]!;
       const newA = createTypedArray(attr.type, total + 1);
-      const newB = createTypedArray(attr.type, total + 1);
       (newA as Uint8Array).set(oldA as Uint8Array);
-      (newB as Uint8Array).set(oldB as Uint8Array);
       newA[total] = defaultValue(attr);
-      newB[total] = defaultValue(attr);
       attrsA[attr.id] = newA;
-      attrsB[attr.id] = newB;
+
+      if (isAsync) {
+        // Async: single buffer — both point to same array
+        attrsB[attr.id] = newA;
+      } else {
+        const oldB = attrsB[attr.id]!;
+        const newB = createTypedArray(attr.type, total + 1);
+        (newB as Uint8Array).set(oldB as Uint8Array);
+        newB[total] = defaultValue(attr);
+        attrsB[attr.id] = newB;
+      }
     }
     readAttrs = attrsA;
-    writeAttrs = attrsB;
+    writeAttrs = isAsync ? attrsA : attrsB;
   }
 }
 
@@ -192,6 +227,7 @@ function buildLoopArgs(): unknown[] {
     args.push(nbr.coords.length);
   }
   args.push(cachedModelAttrs, colors, activeViewer);
+  if (updateMode === 'asynchronous' && orderArray) args.push(orderArray);
   return args;
 }
 
@@ -210,13 +246,33 @@ function buildCellArgs(idx: number): unknown[] {
 
 function runStep(): void {
   const fn = stepFn!;
+
+  // Async mode: shuffle/populate order array before each step
+  if (updateMode === 'asynchronous' && orderArray) {
+    if (asyncScheme === 'random-order') {
+      // Fisher-Yates shuffle — every cell updates exactly once in random order
+      for (let i = total - 1; i > 0; i--) {
+        const j = (Math.random() * (i + 1)) | 0;
+        const tmp = orderArray[i]!; orderArray[i] = orderArray[j]!; orderArray[j] = tmp;
+      }
+    } else if (asyncScheme === 'random-independent') {
+      // N=total random picks with replacement
+      for (let i = 0; i < total; i++) {
+        orderArray[i] = (Math.random() * total) | 0;
+      }
+    }
+    // 'cyclic': orderArray stays as shuffled at init — no per-step work
+  }
+
   // ONE call per step — the loop is inside the compiled function
   fn(...buildLoopArgs());
 
-  // Swap buffers
-  const tmp = readAttrs;
-  readAttrs = writeAttrs;
-  writeAttrs = tmp;
+  // Swap buffers (sync mode only — async uses single buffer)
+  if (updateMode !== 'asynchronous') {
+    const tmp = readAttrs;
+    readAttrs = writeAttrs;
+    writeAttrs = tmp;
+  }
   generation++;
 }
 
@@ -303,6 +359,8 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
       cellAttrs = msg.attributes.filter(a => !a.isModelAttribute);
       neighborhoods = msg.neighborhoods;
       boundaryTreatment = msg.boundaryTreatment;
+      updateMode = msg.updateMode || 'synchronous';
+      asyncScheme = msg.asyncScheme || 'random-order';
 
       // Cache model attributes
       cachedModelAttrs = {};
@@ -389,6 +447,8 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
     }
 
     case 'recompile': {
+      updateMode = msg.updateMode || updateMode;
+      asyncScheme = msg.asyncScheme || asyncScheme;
       compileFns(msg.stepCode, msg.inputColorCodes);
       self.postMessage({ type: 'ready' });
       break;

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -28,10 +28,11 @@ interface InitMsg {
   asyncScheme: string;
   stepCode: string;
   inputColorCodes: Array<{ mappingId: string; code: string }>;
+  outputMappingCodes: Array<{ mappingId: string; code: string }>;
   activeViewer: string;
 }
 
-interface StepMsg { type: 'step'; count: number; activeViewer: string }
+interface StepMsg { type: 'step'; count: number; activeViewer: string; skipColorPass?: boolean }
 interface PaintMsg {
   type: 'paint';
   cells: Array<{ row: number; col: number; r: number; g: number; b: number }>;
@@ -40,7 +41,7 @@ interface PaintMsg {
 }
 interface RandomizeMsg { type: 'randomize'; activeViewer: string }
 interface ResetMsg { type: 'reset'; activeViewer: string }
-interface RecompileMsg { type: 'recompile'; stepCode: string; inputColorCodes: Array<{ mappingId: string; code: string }>; updateMode: string; asyncScheme: string }
+interface RecompileMsg { type: 'recompile'; stepCode: string; inputColorCodes: Array<{ mappingId: string; code: string }>; outputMappingCodes: Array<{ mappingId: string; code: string }>; updateMode: string; asyncScheme: string }
 interface UpdateModelAttrsMsg { type: 'updateModelAttrs'; attrs: Record<string, number> }
 interface ImportImageMsg { type: 'importImage'; pixels: Uint8ClampedArray; mappingId: string; activeViewer: string }
 
@@ -73,6 +74,7 @@ let colors: Uint8ClampedArray = new Uint8ClampedArray(0);
 let orderArray: Int32Array | null = null;
 let stepFn: Function | null = null;
 let inputColorFns: Array<{ mappingId: string; fn: Function }> = [];
+let outputMappingFns: Array<{ mappingId: string; fn: Function }> = [];
 
 // Cached model attributes
 let cachedModelAttrs: Record<string, unknown> = {};
@@ -309,7 +311,9 @@ function randomizeGrid(): void {
     (wArr as Uint8Array).set(arr as Uint8Array);
   }
   generation = 0;
-  if (stepFn) runStep(); else writeDefaultColors();
+  // Prefer Output Mapping color pass (no generation advance) over runStep fallback
+  const hasColorPassR = outputMappingFns.some(f => f.mappingId === activeViewer);
+  if (hasColorPassR) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
 }
 
 function resetGrid(): void {
@@ -320,10 +324,15 @@ function resetGrid(): void {
     for (let i = 0; i < total; i++) { arr[i] = dv; wArr[i] = dv; }
   }
   generation = 0;
-  if (stepFn) runStep(); else writeDefaultColors();
+  const hasColorPassRs = outputMappingFns.some(f => f.mappingId === activeViewer);
+  if (hasColorPassRs) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
 }
 
-function compileFns(stepCode: string, icCodes: Array<{ mappingId: string; code: string }>): void {
+function compileFns(
+  stepCode: string,
+  icCodes: Array<{ mappingId: string; code: string }>,
+  omCodes: Array<{ mappingId: string; code: string }> = [],
+): void {
   try {
     // eslint-disable-next-line no-eval
     stepFn = stepCode ? (eval(stepCode) as Function) : null;
@@ -335,6 +344,19 @@ function compileFns(stepCode: string, icCodes: Array<{ mappingId: string; code: 
       inputColorFns.push({ mappingId: ic.mappingId, fn: eval(ic.code) as Function });
     } catch { /* skip */ }
   }
+  outputMappingFns = [];
+  for (const om of omCodes) {
+    try {
+      // eslint-disable-next-line no-eval
+      outputMappingFns.push({ mappingId: om.mappingId, fn: eval(om.code) as Function });
+    } catch { /* skip */ }
+  }
+}
+
+/** Run the Output Mapping color pass for the active viewer (if available) */
+function runColorPass(): void {
+  const omFn = outputMappingFns.find(f => f.mappingId === activeViewer);
+  if (omFn) omFn.fn(...buildLoopArgs());
 }
 
 function sendColors(): void {
@@ -379,7 +401,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
       activeViewer = msg.activeViewer;
       initGrid();
       buildNeighborIndices();
-      compileFns(msg.stepCode, msg.inputColorCodes);
+      compileFns(msg.stepCode, msg.inputColorCodes, msg.outputMappingCodes || []);
       writeDefaultColors();
       sendColors();
       break;
@@ -392,6 +414,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
       }
       activeViewer = msg.activeViewer;
       for (let i = 0; i < msg.count; i++) runStep();
+      if (!msg.skipColorPass) runColorPass();
       sendColors();
       break;
     }
@@ -424,8 +447,12 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         }
       }
 
-      // Run one step so color viewers update the display
-      if (stepFn) {
+      // Update display: prefer Output Mapping color pass (no generation advance)
+      // over legacy runStep fallback
+      const hasColorPass = outputMappingFns.some(f => f.mappingId === activeViewer);
+      if (hasColorPass) {
+        runColorPass();
+      } else if (stepFn) {
         runStep();
       } else {
         writeDefaultColors();
@@ -435,12 +462,14 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
     }
 
     case 'randomize': {
+      activeViewer = msg.activeViewer;
       randomizeGrid();
       sendColors();
       break;
     }
 
     case 'reset': {
+      activeViewer = msg.activeViewer;
       resetGrid();
       sendColors();
       break;
@@ -449,7 +478,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
     case 'recompile': {
       updateMode = msg.updateMode || updateMode;
       asyncScheme = msg.asyncScheme || asyncScheme;
-      compileFns(msg.stepCode, msg.inputColorCodes);
+      compileFns(msg.stepCode, msg.inputColorCodes, (msg as RecompileMsg).outputMappingCodes || []);
       self.postMessage({ type: 'ready' });
       break;
     }
@@ -478,8 +507,15 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
           readAttrs[attr.id]![idx] = writeAttrs[attr.id]![idx]!;
         }
       }
-      // Run one step for color viewer update
-      if (stepFn) runStep(); else writeDefaultColors();
+      // Update display: prefer Output Mapping color pass (no generation advance)
+      const hasColorPassImg = outputMappingFns.some(f => f.mappingId === activeViewer);
+      if (hasColorPassImg) {
+        runColorPass();
+      } else if (stepFn) {
+        runStep();
+      } else {
+        writeDefaultColors();
+      }
       sendColors();
       break;
     }


### PR DESCRIPTION
## Summary

- **Asynchronous update mode** — cells update sequentially using a single buffer, enabling number-conserving CA models (movement, diffusion). Three update schemes: Random Order, Random Independent, and Cyclic. Configurable in Model Properties > Execution.
- **New async nodes** — Set Neighborhood Attribute and Set Neighbor Attr By Index (async-only, compiler-validated); Get Neighbor Attr By Index (works in both modes). Together they enable the check-then-swap pattern for element movement.
- **Output Mapping (A→C) node** — new event entry point that compiles into a separate sequential color pass running after the Generation Step, ensuring displayed colors always reflect final cell state. Critical for async mode correctness, but useful in sync mode too for separating cell logic from visualization.
- **New "Event" category** — groups the three graph entry points: Generation Step (renamed from Step), Input Mapping C→A (renamed from Input Color), and Output Mapping A→C (new). Bright green, shown first in the Add Node menu.
- **Smarter paint behavior** — when an Output Mapping exists, painting uses the color pass instead of running a generation step, so designing initial configurations no longer advances the simulation. Same for randomize, reset, and image import.
- **Unlimited gens optimization** — color pass is skipped entirely via `skipColorPass` flag for maximum throughput.
- **Six Fundamentals updated** — Writability (`#4`) and Synchronicity (`#6`) now describe both sync and async modes.
- **Documentation fixes** — removed stale "list" attribute type references, corrected node counts (26 types, 7 categories), fixed async-only node classification.
- **Library models** — updated tags (totalistic → outer totalistic), added new property defaults.
