### PR TITLE
Improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ genesis-ca/
 │   │           └── compile.ts        # Two-pass compiler (hoisted values + flow)
 │   ├── simulator/
 │   │   ├── SimulatorView.tsx         # Canvas rendering, zoom/pan, brush tool
+│   │   ├── IndicatorDisplay.tsx      # Indicator values display in simulator
 │   │   └── engine/
 │   │       ├── SimEngine.ts          # Fallback engine (reference only)
 │   │       └── sim.worker.ts         # Web Worker — owns grid, runs steps
@@ -310,6 +311,47 @@ The app is functional with these major systems:
 - Simulator recompile: SimulatorView is conditionally rendered (unmounted on other tabs). Compilation happens automatically on mount via `useEffect([model, compileModel])`. No separate recompile effect needed — graph edits in Modeler are picked up when user switches to Simulator tab.
 - Copy/paste: Ctrl+C/V/X + context menu. Module-level `clipboard` variable, strips macroInput/macroOutput, remaps IDs
 - Group paste: parentId must be remapped to new IDs, children keep relative positions, groups sorted before children
+
+---
+
+## Indicators (Implemented)
+
+### Architecture:
+- Two kinds: **Standalone** (typed scalar, graph-writable) and **Linked** (auto-computed from cell attributes)
+- Standalone indicators support all types: bool, integer, float, tag — stored as JS numbers in `_indicators` object
+- Linked indicators aggregate cell attribute arrays: Frequency (count per value) or Total (sum)
+- Both kinds have Accumulation Mode: per-generation (reset each step) or accumulated (running total, reset on simulator reset)
+
+### Standalone Indicator Nodes:
+- `GetIndicatorNode` (value, `'data'`): reads `_indicators[indicatorId]`
+- `SetIndicatorNode` (flow, `'output'`): writes `_indicators[indicatorId] = value`
+- `UpdateIndicatorNode` (flow, `'output'`): modifies based on type — Bool: toggle/or/and; Int/Float: increment/decrement/max/min; Tag: next/previous
+- All three have teal color `#00695c`
+
+### Compiler Integration:
+- `_indicators` parameter added after `activeViewer`, before optional `order` in `buildLoopParams`, `buildCellParams`, and output mapping params
+- Step function loop-wrapped: `_indicators` is a shared object across all cell iterations within a single step — enables accumulation patterns
+
+### Worker Integration:
+- `cachedIndicators: Record<string, number>` — mutable during step function execution
+- `standalonePerGenIds` — per-generation indicators reset to defaults before each step
+- `computeLinkedIndicators()` — iterates typed arrays after each step (frequency, total, with float binning)
+- `linkedAccumulators` — running state for accumulated linked indicators
+- Indicator values included in `stepped` message as `indicators: Record<string, number | Record<string, number>>`
+- `initIndicators()` called on init, `resetIndicators()` on reset/randomize
+- `updateIndicators` message rebuilds indicator state when definitions change
+
+### Modeler UI:
+- `IndicatorsPanelSection` component rendered inside `PropertiesPanelContent`
+- Standalone: type selector, default value (type-specific), tag options editor
+- Linked: attribute dropdown (cell attrs only), aggregation (type-dependent), bin count (float + frequency only)
+- Both: accumulation mode radio, watched toggle, delete button
+
+### Simulator UI:
+- `IndicatorDisplay` component in right panel below brush controls
+- Scalar values (standalone, linked total): single numeric display
+- Frequency maps (linked frequency): compact table with value→count rows
+- Eye icon per indicator toggles `watched` state
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ A complete GenesisCA model definition consists of:
    - 4.1. Color-Attribute Mappings (input: for initialization, brush tool, and image import)
    - 4.2. Attribute-Color Mappings (output: for visualization modes)
 
-5. **Update Rules** — a node graph defining what each cell computes per generation, compiled into optimized JavaScript at edit time
+5. **Indicators** — quantitative monitoring variables, either standalone (read/write from graph) or linked to cell attributes (auto-computed aggregations: frequency, total)
+
+6. **Update Rules** — a node graph defining what each cell computes per generation, compiled into optimized JavaScript at edit time
 
 ---
 
@@ -65,7 +67,8 @@ A complete GenesisCA model definition consists of:
 - **Attributes Panel** — cell and model attributes with type-specific default value controls (bool, integer, float, tag, color)
 - **Neighborhoods Panel** — interactive grid editor with per-neighborhood margin, and a Duplicate button for quick variations
 - **Mappings Panel** — Attribute-to-Color and Color-to-Attribute mapping definitions
-- **Graph Editor** — 26 node types across 7 categories (event, flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
+- **Indicators** — standalone (typed scalar, graph-writable) or linked (auto-aggregated from cell attributes: frequency, total), with per-generation or accumulated modes
+- **Graph Editor** — 29 node types across 7 categories (event, flow, data, logic, aggregation, output, color), with RMB pan, scroll zoom, and snap-to-grid
 - **Connection validation** — prevents incompatible connections (flow/value), cycles, and duplicate inputs; compatible ports highlight during drag
 - **Inline Port Widgets** — input ports show small value editors (number/bool) when unconnected, eliminating the need for constant nodes in simple cases
 - **Node Collapse/Expand** — double-click any node to collapse it; constants show their value; collapsed nodes temporarily expand when connecting edges

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-ca",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "GPL-3.0-only",
   "scripts": {

--- a/public/models/Particles Random Walk.gcaproj
+++ b/public/models/Particles Random Walk.gcaproj
@@ -1,0 +1,1402 @@
+{
+  "schemaVersion": 1,
+  "properties": {
+    "name": "Particles Random Walk",
+    "author": "Figueiredo",
+    "goal": "Experiment with mass conservation using Asynchronous CA",
+    "description": "Experiment with mass conservation using Asynchronous CA. ",
+    "topology": "2d-grid",
+    "boundaryTreatment": "torus",
+    "gridWidth": 100,
+    "gridHeight": 100,
+    "maxIterations": 1000,
+    "tags": [
+      "2-state",
+      "entropy",
+      "mass conservation"
+    ],
+    "updateMode": "asynchronous",
+    "asyncScheme": "random-order"
+  },
+  "attributes": [
+    {
+      "id": "alive",
+      "name": "alive",
+      "type": "bool",
+      "description": "Whether the cell is alive or dead",
+      "isModelAttribute": false,
+      "defaultValue": "false"
+    },
+    {
+      "id": "new_attribute_4",
+      "name": "Random Paint Probability",
+      "type": "float",
+      "description": "",
+      "isModelAttribute": true,
+      "defaultValue": "0.5"
+    },
+    {
+      "id": "new_attribute_2",
+      "name": "Trace",
+      "type": "integer",
+      "description": "",
+      "isModelAttribute": false,
+      "defaultValue": "false"
+    },
+    {
+      "id": "new_attribute_mnrfw4fpgki",
+      "name": "Move Prob. (Temperature)",
+      "type": "float",
+      "description": "",
+      "isModelAttribute": true,
+      "defaultValue": "0.1"
+    }
+  ],
+  "neighborhoods": [
+    {
+      "id": "moore",
+      "name": "Moore",
+      "description": "All 8 surrounding cells",
+      "coords": [
+        [
+          -1,
+          -1
+        ],
+        [
+          -1,
+          0
+        ],
+        [
+          -1,
+          1
+        ],
+        [
+          0,
+          -1
+        ],
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          -1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          1
+        ]
+      ],
+      "margin": 2
+    }
+  ],
+  "mappings": [
+    {
+      "id": "paint",
+      "name": "SetAlive",
+      "description": "Allows painting alive cells on the grid",
+      "isAttributeToColor": false,
+      "redDescription": ">0",
+      "greenDescription": "",
+      "blueDescription": ""
+    },
+    {
+      "id": "new_mapping_2",
+      "name": "Random",
+      "description": "random",
+      "isAttributeToColor": false,
+      "redDescription": "",
+      "greenDescription": "",
+      "blueDescription": ""
+    },
+    {
+      "id": "new_mapping_6",
+      "name": "Trace",
+      "description": "Displays the cells alive as white dots on a black background, and when a cell dies, it leaves a purple trace that slowly decays.",
+      "isAttributeToColor": true,
+      "redDescription": "",
+      "greenDescription": "",
+      "blueDescription": ""
+    },
+    {
+      "id": "new_mapping_mnrgmrsxq2n",
+      "name": "Binary",
+      "description": "",
+      "isAttributeToColor": true,
+      "redDescription": "",
+      "greenDescription": "",
+      "blueDescription": ""
+    }
+  ],
+  "graphNodes": [
+    {
+      "id": "nmnrg1d8yid1",
+      "type": "groupNode",
+      "position": {
+        "x": -110,
+        "y": 280
+      },
+      "data": {
+        "label": "Update Trace",
+        "width": 920,
+        "height": 440,
+        "nodeType": "group",
+        "config": {},
+        "groupColor": "#2c5847"
+      }
+    },
+    {
+      "id": "nmno07ikvob0",
+      "type": "groupNode",
+      "position": {
+        "x": -870,
+        "y": 180
+      },
+      "data": {
+        "label": "Update Color Output",
+        "width": 740,
+        "height": 405,
+        "nodeType": "group",
+        "config": {},
+        "groupColor": "#9c55aa"
+      }
+    },
+    {
+      "id": "nmno03hqnw4f",
+      "type": "groupNode",
+      "position": {
+        "x": -340,
+        "y": -720
+      },
+      "data": {
+        "label": "Color Input effect (manual brush or image load)",
+        "width": 692.1230707425473,
+        "height": 770,
+        "nodeType": "group",
+        "config": {}
+      }
+    },
+    {
+      "id": "n4",
+      "type": "caNode",
+      "position": {
+        "x": -520,
+        "y": 40
+      },
+      "data": {
+        "nodeType": "step",
+        "config": {}
+      }
+    },
+    {
+      "id": "n6",
+      "type": "caNode",
+      "position": {
+        "x": 81.83515404435137,
+        "y": 47.21700913282251
+      },
+      "data": {
+        "nodeType": "conditional",
+        "config": {}
+      }
+    },
+    {
+      "id": "n7",
+      "type": "caNode",
+      "position": {
+        "x": -120,
+        "y": 100
+      },
+      "data": {
+        "nodeType": "getCellAttribute",
+        "config": {
+          "attributeId": "alive"
+        }
+      }
+    },
+    {
+      "id": "nmnn6ml8mgcs",
+      "type": "caNode",
+      "position": {
+        "x": 40,
+        "y": 40
+      },
+      "data": {
+        "nodeType": "inputColor",
+        "config": {
+          "mappingId": "paint"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnn6niv353r",
+      "type": "caNode",
+      "position": {
+        "x": 233.03100024947162,
+        "y": 147.33550225570912
+      },
+      "data": {
+        "nodeType": "statement",
+        "config": {
+          "operation": ">"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnn6o46hyho",
+      "type": "caNode",
+      "position": {
+        "x": 80,
+        "y": 540
+      },
+      "data": {
+        "nodeType": "getRandom",
+        "config": {
+          "randomType": "float",
+          "min": "0",
+          "max": "1"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnn6pdd7osw",
+      "type": "caNode",
+      "position": {
+        "x": 40,
+        "y": 187.97712308379084
+      },
+      "data": {
+        "nodeType": "getConstant",
+        "config": {
+          "constType": "integer",
+          "constValue": "0"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnn6pqqzgsc",
+      "type": "caNode",
+      "position": {
+        "x": 412.7335237586544,
+        "y": 60
+      },
+      "data": {
+        "nodeType": "setAttribute",
+        "config": {
+          "attributeId": "alive"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnn6qcryjvd",
+      "type": "caNode",
+      "position": {
+        "x": 72.12307074254721,
+        "y": 326.31200399284046
+      },
+      "data": {
+        "nodeType": "inputColor",
+        "config": {
+          "mappingId": "new_mapping_2"
+        },
+        "parentId": "nmno03hqnw4f",
+        "isCollapsed": false
+      }
+    },
+    {
+      "id": "nmnn6qulnxrx",
+      "type": "caNode",
+      "position": {
+        "x": 452.1230707425472,
+        "y": 326.31200399284046
+      },
+      "data": {
+        "nodeType": "setAttribute",
+        "config": {
+          "attributeId": "alive"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnnb8qcry9i",
+      "type": "caNode",
+      "position": {
+        "x": 500,
+        "y": 60
+      },
+      "data": {
+        "nodeType": "setAttribute",
+        "config": {
+          "attributeId": "new_attribute_2",
+          "_port_value": "200"
+        },
+        "parentId": "nmnrg1d8yid1",
+        "isCollapsed": false
+      }
+    },
+    {
+      "id": "nmnnbaxs9dv5",
+      "type": "caNode",
+      "position": {
+        "x": 680,
+        "y": 220
+      },
+      "data": {
+        "nodeType": "setAttribute",
+        "config": {
+          "attributeId": "new_attribute_2"
+        },
+        "parentId": "nmnrg1d8yid1"
+      }
+    },
+    {
+      "id": "nmnnbdeay51o",
+      "type": "caNode",
+      "position": {
+        "x": 40,
+        "y": 280
+      },
+      "data": {
+        "nodeType": "getCellAttribute",
+        "config": {
+          "attributeId": "new_attribute_2"
+        },
+        "parentId": "nmnrg1d8yid1"
+      }
+    },
+    {
+      "id": "nmnnbdiqxonq",
+      "type": "caNode",
+      "position": {
+        "x": 240,
+        "y": 300
+      },
+      "data": {
+        "nodeType": "arithmeticOperator",
+        "config": {
+          "operation": "-",
+          "_port_y": "5"
+        },
+        "parentId": "nmnrg1d8yid1",
+        "isCollapsed": false
+      }
+    },
+    {
+      "id": "nmnnbdzlxupr",
+      "type": "caNode",
+      "position": {
+        "x": 420,
+        "y": 280
+      },
+      "data": {
+        "nodeType": "arithmeticOperator",
+        "config": {
+          "operation": "max"
+        },
+        "parentId": "nmnrg1d8yid1"
+      }
+    },
+    {
+      "id": "nmnnbgx6s4jf",
+      "type": "caNode",
+      "position": {
+        "x": 510,
+        "y": 180
+      },
+      "data": {
+        "nodeType": "setColorViewer",
+        "config": {
+          "mappingId": "new_mapping_6"
+        },
+        "parentId": "nmno07ikvob0",
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnnbh86pr7v",
+      "type": "caNode",
+      "position": {
+        "x": 301,
+        "y": 265
+      },
+      "data": {
+        "nodeType": "getCellAttribute",
+        "config": {
+          "attributeId": "new_attribute_2"
+        },
+        "parentId": "nmno07ikvob0"
+      }
+    },
+    {
+      "id": "nmnncdpy7jkk",
+      "type": "caNode",
+      "position": {
+        "x": 217,
+        "y": 61
+      },
+      "data": {
+        "nodeType": "conditional",
+        "config": {},
+        "parentId": "nmno07ikvob0"
+      }
+    },
+    {
+      "id": "nmnnce6dqlfi",
+      "type": "caNode",
+      "position": {
+        "x": 510,
+        "y": 100
+      },
+      "data": {
+        "nodeType": "setColorViewer",
+        "config": {
+          "mappingId": "new_mapping_6"
+        },
+        "parentId": "nmno07ikvob0",
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnncecbk5u3",
+      "type": "caNode",
+      "position": {
+        "x": 290,
+        "y": 160
+      },
+      "data": {
+        "nodeType": "getConstant",
+        "config": {
+          "constType": "integer",
+          "constValue": "200"
+        },
+        "parentId": "nmno07ikvob0"
+      }
+    },
+    {
+      "id": "nmnncgefih9c",
+      "type": "caNode",
+      "position": {
+        "x": 30,
+        "y": 120
+      },
+      "data": {
+        "nodeType": "getCellAttribute",
+        "config": {
+          "attributeId": "alive"
+        },
+        "parentId": "nmno07ikvob0"
+      }
+    },
+    {
+      "id": "nmno02hwohy7",
+      "type": "caNode",
+      "position": {
+        "x": 272.1230707425472,
+        "y": 386.31200399284046
+      },
+      "data": {
+        "nodeType": "statement",
+        "config": {
+          "operation": ">="
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmno02q10ml6",
+      "type": "caNode",
+      "position": {
+        "x": 60,
+        "y": 460
+      },
+      "data": {
+        "nodeType": "getModelAttribute",
+        "config": {
+          "attributeId": "new_attribute_4"
+        },
+        "parentId": "nmno03hqnw4f"
+      }
+    },
+    {
+      "id": "nmnrfyajyhfa",
+      "type": "caNode",
+      "position": {
+        "x": 490,
+        "y": 180
+      },
+      "data": {
+        "nodeType": "conditional",
+        "config": {},
+        "parentId": "nmnrg1d8yid1"
+      }
+    },
+    {
+      "id": "nmnrfz8hofqh",
+      "type": "caNode",
+      "position": {
+        "x": 270,
+        "y": 180
+      },
+      "data": {
+        "nodeType": "statement",
+        "config": {
+          "operation": ">"
+        },
+        "parentId": "nmnrg1d8yid1"
+      }
+    },
+    {
+      "id": "nmnrg26ygu1v",
+      "type": "caNode",
+      "position": {
+        "x": 860,
+        "y": 20
+      },
+      "data": {
+        "nodeType": "conditional",
+        "config": {},
+        "label": "Move?"
+      }
+    },
+    {
+      "id": "nmnrg2zoskll",
+      "type": "caNode",
+      "position": {
+        "x": 620,
+        "y": -240
+      },
+      "data": {
+        "nodeType": "getNeighborAttributeByIndex",
+        "config": {
+          "neighborhoodId": "moore",
+          "attributeId": "alive"
+        }
+      }
+    },
+    {
+      "id": "nmnrg3s1zizo",
+      "type": "caNode",
+      "position": {
+        "x": 380,
+        "y": 140
+      },
+      "data": {
+        "nodeType": "getRandom",
+        "config": {
+          "randomType": "float",
+          "min": "0",
+          "max": "1"
+        },
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnrg4i4oyjd",
+      "type": "caNode",
+      "position": {
+        "x": 500,
+        "y": 80
+      },
+      "data": {
+        "nodeType": "statement",
+        "config": {
+          "operation": ">="
+        },
+        "isCollapsed": false
+      }
+    },
+    {
+      "id": "nmnrg4mre8kn",
+      "type": "caNode",
+      "position": {
+        "x": 280,
+        "y": 100
+      },
+      "data": {
+        "nodeType": "getModelAttribute",
+        "config": {
+          "attributeId": "new_attribute_mnrfw4fpgki",
+          "isColorAttr": false
+        },
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnrg77qoaat",
+      "type": "caNode",
+      "position": {
+        "x": 680,
+        "y": 60
+      },
+      "data": {
+        "nodeType": "logicOperator",
+        "config": {
+          "operation": "AND"
+        }
+      }
+    },
+    {
+      "id": "nmnrg9jsrz67",
+      "type": "caNode",
+      "position": {
+        "x": 400,
+        "y": -220
+      },
+      "data": {
+        "nodeType": "getRandom",
+        "config": {
+          "randomType": "integer",
+          "min": "0",
+          "max": "7"
+        },
+        "isCollapsed": false
+      }
+    },
+    {
+      "id": "nmnrgd1wxaqq",
+      "type": "caNode",
+      "position": {
+        "x": 700,
+        "y": -120
+      },
+      "data": {
+        "nodeType": "logicOperator",
+        "config": {
+          "operation": "NOT"
+        }
+      }
+    },
+    {
+      "id": "nmnrgfvsnu50",
+      "type": "caNode",
+      "position": {
+        "x": 1140,
+        "y": -120
+      },
+      "data": {
+        "nodeType": "setNeighborAttributeByIndex",
+        "config": {
+          "neighborhoodId": "moore",
+          "attributeId": "alive",
+          "_port_value": "true"
+        }
+      }
+    },
+    {
+      "id": "nmnrggezp92n",
+      "type": "caNode",
+      "position": {
+        "x": 1140,
+        "y": 40
+      },
+      "data": {
+        "nodeType": "setAttribute",
+        "config": {
+          "attributeId": "alive"
+        }
+      }
+    },
+    {
+      "id": "nmnrgn62qrlu",
+      "type": "caNode",
+      "position": {
+        "x": -360,
+        "y": 240
+      },
+      "data": {
+        "nodeType": "setColorViewer",
+        "config": {
+          "mappingId": "new_mapping_mnrgmrsxq2n",
+          "_port_r": "200",
+          "_port_g": "200",
+          "_port_b": "200"
+        },
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnrgnxhzxkd",
+      "type": "caNode",
+      "position": {
+        "x": -360,
+        "y": 320
+      },
+      "data": {
+        "nodeType": "setColorViewer",
+        "config": {
+          "mappingId": "new_mapping_mnrgmrsxq2n",
+          "_port_r": "0",
+          "_port_g": "0",
+          "_port_b": "0"
+        },
+        "isCollapsed": true
+      }
+    },
+    {
+      "id": "nmnsbkcbvzt2",
+      "type": "caNode",
+      "position": {
+        "x": -1060,
+        "y": 220
+      },
+      "data": {
+        "nodeType": "outputMapping",
+        "config": {
+          "mappingId": "new_mapping_6"
+        }
+      }
+    },
+    {
+      "id": "nmnsbkizss2h",
+      "type": "caNode",
+      "position": {
+        "x": -1060,
+        "y": 300
+      },
+      "data": {
+        "nodeType": "outputMapping",
+        "config": {
+          "mappingId": "new_mapping_mnrgmrsxq2n"
+        }
+      }
+    },
+    {
+      "id": "nmnsuvcrp361",
+      "type": "caNode",
+      "position": {
+        "x": 920,
+        "y": -200
+      },
+      "data": {
+        "nodeType": "updateIndicator",
+        "config": {
+          "indicatorId": "indicator_mnsuv1q0fpw",
+          "operation": "increment"
+        }
+      }
+    }
+  ],
+  "graphEdges": [
+    {
+      "id": "xy-edge__n7output_value_value-n6input_value_condition",
+      "source": "n7",
+      "target": "n6",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_condition"
+    },
+    {
+      "id": "xy-edge__nmnn6ml8mgcsoutput_value_r-nmnn6niv353rinput_value_x",
+      "source": "nmnn6ml8mgcs",
+      "target": "nmnn6niv353r",
+      "sourceHandle": "output_value_r",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnn6pdd7oswoutput_value_value-nmnn6niv353rinput_value_y",
+      "source": "nmnn6pdd7osw",
+      "target": "nmnn6niv353r",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_y"
+    },
+    {
+      "id": "xy-edge__nmnn6ml8mgcsoutput_flow_do-nmnn6pqqzgscinput_flow_do",
+      "source": "nmnn6ml8mgcs",
+      "target": "nmnn6pqqzgsc",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnn6niv353routput_value_result-nmnn6pqqzgscinput_value_value",
+      "source": "nmnn6niv353r",
+      "target": "nmnn6pqqzgsc",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_value"
+    },
+    {
+      "id": "xy-edge__nmnn6qcryjvdoutput_flow_do-nmnn6qulnxrxinput_flow_do",
+      "source": "nmnn6qcryjvd",
+      "target": "nmnn6qulnxrx",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnnbdeay51ooutput_value_value-nmnnbdiqxonqinput_value_x",
+      "source": "nmnnbdeay51o",
+      "target": "nmnnbdiqxonq",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnnbdiqxonqoutput_value_result-nmnnbdzlxuprinput_value_x",
+      "source": "nmnnbdiqxonq",
+      "target": "nmnnbdzlxupr",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnnbdzlxuproutput_value_result-nmnnbaxs9dv5input_value_value",
+      "source": "nmnnbdzlxupr",
+      "target": "nmnnbaxs9dv5",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_value"
+    },
+    {
+      "id": "xy-edge__nmnnbh86pr7voutput_value_value-nmnnbgx6s4jfinput_value_r",
+      "source": "nmnnbh86pr7v",
+      "target": "nmnnbgx6s4jf",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_r"
+    },
+    {
+      "id": "xy-edge__nmnnbh86pr7voutput_value_value-nmnnbgx6s4jfinput_value_b",
+      "source": "nmnnbh86pr7v",
+      "target": "nmnnbgx6s4jf",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_b"
+    },
+    {
+      "id": "xy-edge__nmnncdpy7jkkoutput_flow_then-nmnnce6dqlfiinput_flow_do",
+      "source": "nmnncdpy7jkk",
+      "target": "nmnnce6dqlfi",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_r",
+      "source": "nmnncecbk5u3",
+      "target": "nmnnce6dqlfi",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_r"
+    },
+    {
+      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_b",
+      "source": "nmnncecbk5u3",
+      "target": "nmnnce6dqlfi",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_b"
+    },
+    {
+      "id": "xy-edge__nmnncecbk5u3output_value_value-nmnnce6dqlfiinput_value_g",
+      "source": "nmnncecbk5u3",
+      "target": "nmnnce6dqlfi",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_g"
+    },
+    {
+      "id": "xy-edge__nmnncdpy7jkkoutput_flow_else-nmnnbgx6s4jfinput_flow_do",
+      "source": "nmnncdpy7jkk",
+      "target": "nmnnbgx6s4jf",
+      "sourceHandle": "output_flow_else",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnncgefih9coutput_value_value-nmnncdpy7jkkinput_value_condition",
+      "source": "nmnncgefih9c",
+      "target": "nmnncdpy7jkk",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_condition"
+    },
+    {
+      "id": "xy-edge__nmno02hwohy7output_value_result-nmnn6qulnxrxinput_value_value",
+      "source": "nmno02hwohy7",
+      "target": "nmnn6qulnxrx",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_value"
+    },
+    {
+      "id": "xy-edge__nmnn6o46hyhooutput_value_value-nmno02hwohy7input_value_y",
+      "source": "nmnn6o46hyho",
+      "target": "nmno02hwohy7",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_y"
+    },
+    {
+      "id": "xy-edge__nmno02q10ml6output_value_value-nmno02hwohy7input_value_x",
+      "source": "nmno02q10ml6",
+      "target": "nmno02hwohy7",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnnbdeay51ooutput_value_value-nmnrfz8hofqhinput_value_x",
+      "source": "nmnnbdeay51o",
+      "target": "nmnrfz8hofqh",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnrfz8hofqhoutput_value_result-nmnrfyajyhfainput_value_condition",
+      "source": "nmnrfz8hofqh",
+      "target": "nmnrfyajyhfa",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_condition"
+    },
+    {
+      "id": "xy-edge__nmnrfyajyhfaoutput_flow_then-nmnnbaxs9dv5input_flow_do",
+      "source": "nmnrfyajyhfa",
+      "target": "nmnnbaxs9dv5",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__n6output_flow_then-nmnrg26ygu1vinput_flow_check",
+      "source": "n6",
+      "target": "nmnrg26ygu1v",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__nmnrg4mre8knoutput_value_value-nmnrg4i4oyjdinput_value_x",
+      "source": "nmnrg4mre8kn",
+      "target": "nmnrg4i4oyjd",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_x"
+    },
+    {
+      "id": "xy-edge__nmnrg3s1zizooutput_value_value-nmnrg4i4oyjdinput_value_y",
+      "source": "nmnrg3s1zizo",
+      "target": "nmnrg4i4oyjd",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_y"
+    },
+    {
+      "id": "xy-edge__nmnrg4i4oyjdoutput_value_result-nmnrg77qoaatinput_value_b",
+      "source": "nmnrg4i4oyjd",
+      "target": "nmnrg77qoaat",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_b"
+    },
+    {
+      "id": "xy-edge__nmnrg2zosklloutput_value_value-nmnrgd1wxaqqinput_value_a",
+      "source": "nmnrg2zoskll",
+      "target": "nmnrgd1wxaqq",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_a"
+    },
+    {
+      "id": "xy-edge__nmnrgd1wxaqqoutput_value_result-nmnrg77qoaatinput_value_a",
+      "source": "nmnrgd1wxaqq",
+      "target": "nmnrg77qoaat",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_a"
+    },
+    {
+      "id": "xy-edge__nmnrg77qoaatoutput_value_result-nmnrg26ygu1vinput_value_condition",
+      "source": "nmnrg77qoaat",
+      "target": "nmnrg26ygu1v",
+      "sourceHandle": "output_value_result",
+      "targetHandle": "input_value_condition"
+    },
+    {
+      "id": "xy-edge__nmnrg26ygu1voutput_flow_then-nmnrgfvsnu50input_flow_do",
+      "source": "nmnrg26ygu1v",
+      "target": "nmnrgfvsnu50",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnrg26ygu1voutput_flow_then-nmnrggezp92ninput_flow_do",
+      "source": "nmnrg26ygu1v",
+      "target": "nmnrggezp92n",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnncdpy7jkkoutput_flow_then-nmnrgn62qrluinput_flow_do",
+      "source": "nmnncdpy7jkk",
+      "target": "nmnrgn62qrlu",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnncdpy7jkkoutput_flow_else-nmnrgnxhzxkdinput_flow_do",
+      "source": "nmnncdpy7jkk",
+      "target": "nmnrgnxhzxkd",
+      "sourceHandle": "output_flow_else",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnrg9jsrz67output_value_value-nmnrg2zoskllinput_value_index",
+      "source": "nmnrg9jsrz67",
+      "target": "nmnrg2zoskll",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_index"
+    },
+    {
+      "id": "xy-edge__nmnrg9jsrz67output_value_value-nmnrgfvsnu50input_value_index",
+      "source": "nmnrg9jsrz67",
+      "target": "nmnrgfvsnu50",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_index"
+    },
+    {
+      "id": "xy-edge__nmnsbkcbvzt2output_flow_do-nmnncdpy7jkkinput_flow_check",
+      "source": "nmnsbkcbvzt2",
+      "target": "nmnncdpy7jkk",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__nmnsbkizss2houtput_flow_do-nmnncdpy7jkkinput_flow_check",
+      "source": "nmnsbkizss2h",
+      "target": "nmnncdpy7jkk",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__n6output_flow_then-nmnnb8qcry9iinput_flow_do",
+      "source": "n6",
+      "target": "nmnnb8qcry9i",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__n6output_flow_else-nmnrfyajyhfainput_flow_check",
+      "source": "n6",
+      "target": "nmnrfyajyhfa",
+      "sourceHandle": "output_flow_else",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__n4output_flow_do-n6input_flow_check",
+      "source": "n4",
+      "target": "n6",
+      "sourceHandle": "output_flow_do",
+      "targetHandle": "input_flow_check"
+    },
+    {
+      "id": "xy-edge__n6output_flow_then-nmnsuvcrp361input_flow_do",
+      "source": "n6",
+      "target": "nmnsuvcrp361",
+      "sourceHandle": "output_flow_then",
+      "targetHandle": "input_flow_do"
+    },
+    {
+      "id": "xy-edge__nmnrg2zosklloutput_value_value-nmnsuvcrp361input_value_value",
+      "source": "nmnrg2zoskll",
+      "target": "nmnsuvcrp361",
+      "sourceHandle": "output_value_value",
+      "targetHandle": "input_value_value"
+    }
+  ],
+  "macroDefs": [
+    {
+      "id": "macro_mno12xxa",
+      "name": "Decide Life State",
+      "nodes": [
+        {
+          "id": "n12",
+          "type": "caNode",
+          "position": {
+            "x": 920,
+            "y": 240
+          },
+          "data": {
+            "nodeType": "getConstant",
+            "config": {
+              "constType": "integer",
+              "constValue": "3"
+            }
+          }
+        },
+        {
+          "id": "nmnn2k5xb14d",
+          "type": "caNode",
+          "position": {
+            "x": 1100,
+            "y": 180
+          },
+          "data": {
+            "nodeType": "statement",
+            "config": {
+              "operation": "=="
+            }
+          }
+        },
+        {
+          "id": "n13",
+          "type": "caNode",
+          "position": {
+            "x": 540,
+            "y": 260
+          },
+          "data": {
+            "nodeType": "getNeighborsAttribute",
+            "config": {
+              "neighborhoodId": "moore",
+              "attributeId": "alive"
+            }
+          }
+        },
+        {
+          "id": "n15",
+          "type": "caNode",
+          "position": {
+            "x": 752,
+            "y": 314
+          },
+          "data": {
+            "nodeType": "groupCounting",
+            "config": {
+              "operation": "equals"
+            }
+          }
+        },
+        {
+          "id": "n16",
+          "type": "caNode",
+          "position": {
+            "x": 548,
+            "y": 369
+          },
+          "data": {
+            "nodeType": "getConstant",
+            "config": {
+              "constType": "bool",
+              "constValue": "true"
+            }
+          }
+        },
+        {
+          "id": "n17",
+          "type": "caNode",
+          "position": {
+            "x": 1300,
+            "y": 440
+          },
+          "data": {
+            "nodeType": "logicOperator",
+            "config": {
+              "operation": "OR"
+            }
+          }
+        },
+        {
+          "id": "n19",
+          "type": "caNode",
+          "position": {
+            "x": 920,
+            "y": 520
+          },
+          "data": {
+            "nodeType": "getConstant",
+            "config": {
+              "constType": "integer",
+              "constValue": "3"
+            }
+          }
+        },
+        {
+          "id": "nmnn2j2c6nl2",
+          "type": "caNode",
+          "position": {
+            "x": 1100,
+            "y": 380
+          },
+          "data": {
+            "nodeType": "statement",
+            "config": {
+              "operation": "<"
+            },
+            "label": "Underpopulation"
+          }
+        },
+        {
+          "id": "nmnn2j7ugi7l",
+          "type": "caNode",
+          "position": {
+            "x": 1100,
+            "y": 500
+          },
+          "data": {
+            "nodeType": "statement",
+            "config": {
+              "operation": ">"
+            },
+            "label": "Overpopulation"
+          }
+        },
+        {
+          "id": "nmnn2jj7vpky",
+          "type": "caNode",
+          "position": {
+            "x": 900,
+            "y": 400
+          },
+          "data": {
+            "nodeType": "getConstant",
+            "config": {
+              "constType": "integer",
+              "constValue": "2"
+            }
+          }
+        },
+        {
+          "id": "mi_macro_mno12xxa",
+          "type": "caNode",
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "data": {
+            "nodeType": "macroInput",
+            "config": {
+              "macroDefId": "macro_mno12xxa"
+            }
+          }
+        },
+        {
+          "id": "mo_macro_mno12xxa",
+          "type": "caNode",
+          "position": {
+            "x": 1520,
+            "y": 320
+          },
+          "data": {
+            "nodeType": "macroOutput",
+            "config": {
+              "macroDefId": "macro_mno12xxa"
+            }
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "xy-edge__n12output_value_value-nmnn2k5xb14dinput_value_y",
+          "source": "n12",
+          "target": "nmnn2k5xb14d",
+          "sourceHandle": "output_value_value",
+          "targetHandle": "input_value_y"
+        },
+        {
+          "id": "xy-edge__n13output_value_values-n15input_value_values",
+          "source": "n13",
+          "target": "n15",
+          "sourceHandle": "output_value_values",
+          "targetHandle": "input_value_values"
+        },
+        {
+          "id": "xy-edge__n16output_value_value-n15input_value_compare",
+          "source": "n16",
+          "target": "n15",
+          "sourceHandle": "output_value_value",
+          "targetHandle": "input_value_compare"
+        },
+        {
+          "id": "xy-edge__n15output_value_count-nmnn2j7ugi7linput_value_x",
+          "source": "n15",
+          "target": "nmnn2j7ugi7l",
+          "sourceHandle": "output_value_count",
+          "targetHandle": "input_value_x"
+        },
+        {
+          "id": "xy-edge__n19output_value_value-nmnn2j7ugi7linput_value_y",
+          "source": "n19",
+          "target": "nmnn2j7ugi7l",
+          "sourceHandle": "output_value_value",
+          "targetHandle": "input_value_y"
+        },
+        {
+          "id": "xy-edge__n15output_value_count-nmnn2j2c6nl2input_value_x",
+          "source": "n15",
+          "target": "nmnn2j2c6nl2",
+          "sourceHandle": "output_value_count",
+          "targetHandle": "input_value_x"
+        },
+        {
+          "id": "xy-edge__nmnn2jj7vpkyoutput_value_value-nmnn2j2c6nl2input_value_y",
+          "source": "nmnn2jj7vpky",
+          "target": "nmnn2j2c6nl2",
+          "sourceHandle": "output_value_value",
+          "targetHandle": "input_value_y"
+        },
+        {
+          "id": "xy-edge__nmnn2j2c6nl2output_value_result-n17input_value_a",
+          "source": "nmnn2j2c6nl2",
+          "target": "n17",
+          "sourceHandle": "output_value_result",
+          "targetHandle": "input_value_a"
+        },
+        {
+          "id": "xy-edge__nmnn2j7ugi7loutput_value_result-n17input_value_b",
+          "source": "nmnn2j7ugi7l",
+          "target": "n17",
+          "sourceHandle": "output_value_result",
+          "targetHandle": "input_value_b"
+        },
+        {
+          "id": "restored_xy-edge__nmno0kmwvvjgoutput_value_out_mno0kzhr6og-nmnn2k5xb14dinput_value_x",
+          "source": "n15",
+          "target": "nmnn2k5xb14d",
+          "sourceHandle": "output_value_count",
+          "targetHandle": "input_value_x"
+        },
+        {
+          "id": "xy-edge__nmnn2k5xb14doutput_value_result-mo_macro_mno12xxainput_value_out_1",
+          "source": "nmnn2k5xb14d",
+          "target": "mo_macro_mno12xxa",
+          "sourceHandle": "output_value_result",
+          "targetHandle": "input_value_out_1"
+        },
+        {
+          "id": "xy-edge__n17output_value_result-mo_macro_mno12xxainput_value_out_0",
+          "source": "n17",
+          "target": "mo_macro_mno12xxa",
+          "sourceHandle": "output_value_result",
+          "targetHandle": "input_value_out_0"
+        }
+      ],
+      "exposedInputs": [],
+      "exposedOutputs": [
+        {
+          "portId": "out_0",
+          "label": "Must Die",
+          "dataType": "any",
+          "category": "value",
+          "internalNodeId": "mo_macro_mno12xxa",
+          "internalPortId": "out_0"
+        },
+        {
+          "portId": "out_1",
+          "label": "Must be Born",
+          "dataType": "any",
+          "category": "value",
+          "internalNodeId": "mo_macro_mno12xxa",
+          "internalPortId": "out_1"
+        }
+      ]
+    }
+  ],
+  "indicators": [
+    {
+      "id": "indicator_mnsuurz1kuk",
+      "name": "#Particles",
+      "kind": "linked",
+      "dataType": "bool",
+      "defaultValue": "0",
+      "accumulationMode": "per-generation",
+      "watched": true,
+      "linkedAttributeId": "alive",
+      "linkedAggregation": "frequency"
+    },
+    {
+      "id": "indicator_mnsuv1q0fpw",
+      "name": "Collisions",
+      "kind": "standalone",
+      "dataType": "integer",
+      "defaultValue": "0",
+      "accumulationMode": "per-generation",
+      "watched": true
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ function AppInner() {
               1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
           </svg>
         </a>
-        <span className={styles.title}>GenesisCA <span className={styles.version}>v1.3.0</span></span>
+        <span className={styles.title}>GenesisCA <span className={styles.version}>v1.4.0</span></span>
         <div className={styles.navTabs}>
           <button
             className={`${styles.navButton} ${mode === 'modeler' ? styles.navButtonActive : ''}`}

--- a/src/help/HelpView.tsx
+++ b/src/help/HelpView.tsx
@@ -152,6 +152,35 @@ export function HelpView() {
             colors into cell state changes.
           </p>
 
+          <h3 className={styles.h3}>Indicators (Properties Panel)</h3>
+          <p className={styles.p}>
+            Indicators are quantitative variables that monitor CA evolution beyond visual
+            feedback. They are defined in the <strong>Properties</strong> panel under the
+            &quot;Indicators&quot; section. Two kinds exist:
+          </p>
+          <ul className={styles.list}>
+            <li><strong>Standalone</strong> &mdash; Typed scalar values (bool, integer, float,
+            or tag) that can be read and written by graph nodes (Get Indicator, Set Indicator,
+            Update Indicator). They act as accumulators inside the step loop.</li>
+            <li><strong>Linked</strong> &mdash; Automatically computed from an existing cell
+            attribute after each step. The aggregation mode depends on the attribute type:
+            Bool and Tag support Frequency (count per value); Integer and Float support
+            Total (sum) or Frequency.</li>
+          </ul>
+          <p className={styles.p}>
+            Each indicator has an <strong>Accumulation Mode</strong>: &quot;Per
+            Generation&quot; resets every step, while &quot;Accumulated&quot; keeps a running
+            total across generations (reset on simulator reset).
+          </p>
+          <p className={styles.p}>
+            In the Simulator, the <strong>eye icon</strong> on linked indicators toggles
+            whether the aggregation is computed. Unwatching a linked indicator removes its
+            computation from the step loop, saving performance. For <strong>Accumulated</strong>
+            linked indicators, unwatching means those generations are skipped in the running
+            total. Standalone indicator eye icons are always active (disabled) because their
+            computation is part of the user-defined update graph and cannot be separated.
+          </p>
+
           <h3 className={styles.h3}>The Graph Editor</h3>
           <p className={styles.p}>
             The central area is a node-based visual programming editor. You connect nodes
@@ -300,6 +329,18 @@ export function HelpView() {
             <tbody>
               <tr><td>Set Color Viewer</td><td>Write RGB values for an Attribute-to-Color visualization.</td></tr>
               <tr><td>Get Color Constant</td><td>Output fixed R, G, B values.</td></tr>
+            </tbody>
+          </table>
+
+          <h3 className={styles.h3}>
+            Indicators
+          </h3>
+          <table className={styles.table}>
+            <thead><tr><th>Node</th><th>Description</th></tr></thead>
+            <tbody>
+              <tr><td>Get Indicator</td><td>Read the current value of a standalone indicator.</td></tr>
+              <tr><td>Set Indicator</td><td>Set a standalone indicator to a specific value.</td></tr>
+              <tr><td>Update Indicator</td><td>Modify a standalone indicator based on its current value and an input (increment, decrement, max, min, toggle, OR, AND, next, previous).</td></tr>
             </tbody>
           </table>
         </section>

--- a/src/model/ModelContext.tsx
+++ b/src/model/ModelContext.tsx
@@ -12,6 +12,8 @@ import type {
   CAModel,
   GraphEdge,
   GraphNode,
+  Indicator,
+  IndicatorKind,
   MacroDef,
   Mapping,
   ModelProperties,
@@ -58,6 +60,9 @@ type ModelAction =
   | { type: 'ADD_MACRO'; macro: MacroDef }
   | { type: 'UPDATE_MACRO'; id: string; changes: Partial<MacroDef> }
   | { type: 'REMOVE_MACRO'; id: string }
+  | { type: 'ADD_INDICATOR'; kind: IndicatorKind }
+  | { type: 'REMOVE_INDICATOR'; id: string }
+  | { type: 'UPDATE_INDICATOR'; id: string; changes: Partial<Indicator> }
   | { type: 'NEW_MODEL' }
   | { type: 'LOAD_MODEL'; model: CAModel }
   | { type: 'MARK_SAVED' };
@@ -266,6 +271,48 @@ function modelReducer(state: ModelState, action: ModelAction): ModelState {
         },
       };
 
+    case 'ADD_INDICATOR': {
+      const newInd: Indicator = {
+        id: generateId('indicator'),
+        name: 'new_indicator',
+        kind: action.kind,
+        dataType: 'integer',
+        defaultValue: '0',
+        accumulationMode: 'per-generation',
+        watched: true,
+      };
+      return {
+        ...state,
+        isDirty: true,
+        model: {
+          ...state.model,
+          indicators: [...(state.model.indicators || []), newInd],
+        },
+      };
+    }
+
+    case 'REMOVE_INDICATOR':
+      return {
+        ...state,
+        isDirty: true,
+        model: {
+          ...state.model,
+          indicators: (state.model.indicators || []).filter(i => i.id !== action.id),
+        },
+      };
+
+    case 'UPDATE_INDICATOR':
+      return {
+        ...state,
+        isDirty: true,
+        model: {
+          ...state.model,
+          indicators: (state.model.indicators || []).map(i =>
+            i.id === action.id ? { ...i, ...action.changes } : i,
+          ),
+        },
+      };
+
     case 'NEW_MODEL':
       return { model: EMPTY_MODEL, isDirty: false, modelVersion: state.modelVersion + 1 };
 
@@ -275,6 +322,7 @@ function modelReducer(state: ModelState, action: ModelAction): ModelState {
       if (!m.graphNodes) m.graphNodes = [];
       if (!m.graphEdges) m.graphEdges = [];
       if (!m.macroDefs) m.macroDefs = [];
+      if (!m.indicators) m.indicators = [];
       if (!m.properties.tags) m.properties.tags = [];
       if (!m.properties.updateMode) m.properties.updateMode = 'synchronous';
       if (!m.properties.asyncScheme) m.properties.asyncScheme = 'random-order';
@@ -313,6 +361,9 @@ export interface ModelContextValue {
   addMacro: (macro: MacroDef) => void;
   updateMacro: (id: string, changes: Partial<MacroDef>) => void;
   removeMacro: (id: string) => void;
+  addIndicator: (kind: IndicatorKind) => void;
+  removeIndicator: (id: string) => void;
+  updateIndicator: (id: string, changes: Partial<Indicator>) => void;
   newModel: () => void;
   loadModel: (model: CAModel) => void;
   markSaved: () => void;
@@ -334,6 +385,7 @@ function createInitialState(): ModelState {
         if (!model.graphNodes) model.graphNodes = [];
         if (!model.graphEdges) model.graphEdges = [];
         if (!model.macroDefs) model.macroDefs = [];
+        if (!model.indicators) model.indicators = [];
         if (!model.properties.tags) model.properties.tags = [];
         if (!model.properties.updateMode) model.properties.updateMode = 'synchronous';
         if (!model.properties.asyncScheme) model.properties.asyncScheme = 'random-order';
@@ -458,6 +510,19 @@ export function ModelProvider({ children }: { children: ReactNode }) {
     (id: string) => dispatch({ type: 'REMOVE_MACRO', id }),
     [],
   );
+  const addIndicator = useCallback(
+    (kind: IndicatorKind) => dispatch({ type: 'ADD_INDICATOR', kind }),
+    [],
+  );
+  const removeIndicator = useCallback(
+    (id: string) => dispatch({ type: 'REMOVE_INDICATOR', id }),
+    [],
+  );
+  const updateIndicator = useCallback(
+    (id: string, changes: Partial<Indicator>) =>
+      dispatch({ type: 'UPDATE_INDICATOR', id, changes }),
+    [],
+  );
   const newModel = useCallback(() => {
     dispatch({ type: 'NEW_MODEL' });
     try { localStorage.removeItem('genesisca_autosave'); } catch { /* ok */ }
@@ -491,6 +556,9 @@ export function ModelProvider({ children }: { children: ReactNode }) {
       addMacro,
       updateMacro,
       removeMacro,
+      addIndicator,
+      removeIndicator,
+      updateIndicator,
       newModel,
       loadModel,
       markSaved,
@@ -514,6 +582,9 @@ export function ModelProvider({ children }: { children: ReactNode }) {
       addMacro,
       updateMacro,
       removeMacro,
+      addIndicator,
+      removeIndicator,
+      updateIndicator,
       newModel,
       loadModel,
       markSaved,

--- a/src/model/defaultModel.ts
+++ b/src/model/defaultModel.ts
@@ -21,6 +21,7 @@ export const EMPTY_MODEL: CAModel = {
   attributes: [],
   neighborhoods: [],
   mappings: [],
+  indicators: [],
   graphNodes: [],
   graphEdges: [],
   macroDefs: [],

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -91,6 +91,31 @@ export interface MacroDef {
   exposedOutputs: MacroPort[];
 }
 
+// ---------------------------------------------------------------------------
+// Indicators
+// ---------------------------------------------------------------------------
+
+export type IndicatorKind = 'standalone' | 'linked';
+export type LinkedAggregation = 'frequency' | 'total';
+export type AccumulationMode = 'per-generation' | 'accumulated';
+
+/** An indicator definition — monitors CA evolution quantitatively */
+export interface Indicator {
+  id: string;
+  name: string;
+  kind: IndicatorKind;
+  dataType: AttributeType;              // standalone: user-chosen; linked: derived from linked attr (excludes 'color')
+  defaultValue: string;                 // standalone: initial/reset value (same format as Attribute.defaultValue)
+  accumulationMode: AccumulationMode;
+  tagOptions?: string[];                // standalone tag type: named values (like Attribute.tagOptions)
+  // Linked-only fields:
+  linkedAttributeId?: string;
+  linkedAggregation?: LinkedAggregation;
+  binCount?: number;                    // float + frequency: number of histogram bins (default 10)
+  // Display:
+  watched: boolean;                     // eye toggle — controls display in simulator
+}
+
 /** Complete CA model definition */
 export interface CAModel {
   schemaVersion: number;
@@ -98,6 +123,7 @@ export interface CAModel {
   attributes: Attribute[];
   neighborhoods: Neighborhood[];
   mappings: Mapping[];
+  indicators: Indicator[];
   graphNodes: GraphNode[];
   graphEdges: GraphEdge[];
   macroDefs: MacroDef[];

--- a/src/modeler/panels/IndicatorsPanelSection.tsx
+++ b/src/modeler/panels/IndicatorsPanelSection.tsx
@@ -1,0 +1,272 @@
+import { useState } from 'react';
+import { useModel } from '../../model/ModelContext';
+import type { AttributeType, LinkedAggregation } from '../../model/types';
+import styles from './PanelContent.module.css';
+
+export function IndicatorsPanelSection() {
+  const { model, addIndicator, removeIndicator, updateIndicator } = useModel();
+  const indicators = model.indicators || [];
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = indicators.find(i => i.id === selectedId);
+
+  const cellAttrs = model.attributes.filter(a => !a.isModelAttribute);
+
+  const getAggregationOptions = (attrType: string): Array<{ value: LinkedAggregation; label: string }> => {
+    switch (attrType) {
+      case 'bool': return [{ value: 'frequency', label: 'Frequency' }];
+      case 'tag':  return [{ value: 'frequency', label: 'Frequency' }];
+      case 'integer':
+      case 'float':
+        return [
+          { value: 'total', label: 'Total (Sum)' },
+          { value: 'frequency', label: 'Frequency' },
+        ];
+      default: return [{ value: 'frequency', label: 'Frequency' }];
+    }
+  };
+
+  const linkedAttr = selected?.kind === 'linked'
+    ? cellAttrs.find(a => a.id === selected.linkedAttributeId)
+    : undefined;
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>Indicators</div>
+
+      <div className={styles.list}>
+        {indicators.map(ind => (
+          <div
+            key={ind.id}
+            className={`${styles.listItem} ${ind.id === selectedId ? styles.listItemSelected : ''}`}
+            onClick={() => setSelectedId(ind.id === selectedId ? null : ind.id)}
+          >
+            <span className={styles.listItemName}>{ind.name}</span>
+            <span className={styles.listItemBadge}>{ind.kind === 'standalone' ? 'Standalone' : 'Linked'}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.buttonRow}>
+        <button className={styles.addButton} onClick={() => addIndicator('standalone')}>+ Standalone</button>
+        <button className={styles.addButton} onClick={() => addIndicator('linked')}>+ Linked</button>
+      </div>
+
+      {selected && (
+        <div className={styles.detailEditor}>
+          <div className={styles.fieldGroup}>
+            <div className={styles.field}>
+              <label className={styles.fieldLabel}>Name</label>
+              <input
+                className={styles.textInput}
+                value={selected.name}
+                onChange={e => updateIndicator(selected.id, { name: e.target.value })}
+              />
+            </div>
+
+            {selected.kind === 'standalone' && (
+              <>
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>Data Type</label>
+                  <select
+                    className={styles.selectInput}
+                    value={selected.dataType || 'integer'}
+                    onChange={e => {
+                      const dt = e.target.value as AttributeType;
+                      const defaults: Record<string, string> = {
+                        bool: 'false', integer: '0', float: '0', tag: '0',
+                      };
+                      updateIndicator(selected.id, {
+                        dataType: dt,
+                        defaultValue: defaults[dt] || '0',
+                        tagOptions: dt === 'tag' ? [] : undefined,
+                      });
+                    }}
+                  >
+                    <option value="bool">Bool</option>
+                    <option value="integer">Integer</option>
+                    <option value="float">Float</option>
+                    <option value="tag">Tag</option>
+                  </select>
+                </div>
+
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>Default Value</label>
+                  {selected.dataType === 'bool' ? (
+                    <select
+                      className={styles.selectInput}
+                      value={selected.defaultValue === 'true' ? 'true' : 'false'}
+                      onChange={e => updateIndicator(selected.id, { defaultValue: e.target.value })}
+                    >
+                      <option value="false">false</option>
+                      <option value="true">true</option>
+                    </select>
+                  ) : selected.dataType === 'tag' ? (
+                    <select
+                      className={styles.selectInput}
+                      value={selected.defaultValue || '0'}
+                      onChange={e => updateIndicator(selected.id, { defaultValue: e.target.value })}
+                    >
+                      {(selected.tagOptions || []).length > 0
+                        ? (selected.tagOptions || []).map((t, i) => (
+                            <option key={i} value={String(i)}>{t}</option>
+                          ))
+                        : <option value="0">0</option>}
+                    </select>
+                  ) : (
+                    <input
+                      className={styles.numberInput}
+                      type="number"
+                      value={selected.defaultValue || '0'}
+                      onChange={e => updateIndicator(selected.id, { defaultValue: e.target.value })}
+                    />
+                  )}
+                </div>
+
+                {selected.dataType === 'tag' && (
+                  <TagOptionsEditor
+                    options={selected.tagOptions || []}
+                    onChange={opts => updateIndicator(selected.id, { tagOptions: opts })}
+                  />
+                )}
+              </>
+            )}
+
+            {selected.kind === 'linked' && (
+              <>
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>Linked Attribute</label>
+                  <select
+                    className={styles.selectInput}
+                    value={selected.linkedAttributeId || ''}
+                    onChange={e => {
+                      const attr = cellAttrs.find(a => a.id === e.target.value);
+                      const aggOpts = attr ? getAggregationOptions(attr.type) : [];
+                      updateIndicator(selected.id, {
+                        linkedAttributeId: e.target.value,
+                        dataType: (attr?.type || 'integer') as AttributeType,
+                        linkedAggregation: aggOpts[0]?.value || 'frequency',
+                      });
+                    }}
+                  >
+                    <option value="">Select...</option>
+                    {cellAttrs.map(a => (
+                      <option key={a.id} value={a.id}>{a.name} ({a.type})</option>
+                    ))}
+                  </select>
+                </div>
+
+                {linkedAttr && (
+                  <div className={styles.field}>
+                    <label className={styles.fieldLabel}>Aggregation</label>
+                    <select
+                      className={styles.selectInput}
+                      value={selected.linkedAggregation || 'frequency'}
+                      onChange={e => updateIndicator(selected.id, { linkedAggregation: e.target.value as LinkedAggregation })}
+                    >
+                      {getAggregationOptions(linkedAttr.type).map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                {linkedAttr?.type === 'float' && selected.linkedAggregation === 'frequency' && (
+                  <div className={styles.field}>
+                    <label className={styles.fieldLabel}>Bin Count</label>
+                    <input
+                      className={styles.numberInput}
+                      type="number"
+                      min={2}
+                      max={100}
+                      value={selected.binCount ?? 10}
+                      onChange={e => updateIndicator(selected.id, { binCount: Math.max(2, Math.min(100, Number(e.target.value) || 10)) })}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+
+            <div className={styles.field}>
+              <label className={styles.fieldLabel}>Accumulation</label>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 2 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: '0.72rem' }}>
+                  <input
+                    type="radio"
+                    name={`accum_${selected.id}`}
+                    checked={selected.accumulationMode !== 'accumulated'}
+                    onChange={() => updateIndicator(selected.id, { accumulationMode: 'per-generation' })}
+                  />
+                  <span>Per Generation</span>
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: '0.72rem' }}>
+                  <input
+                    type="radio"
+                    name={`accum_${selected.id}`}
+                    checked={selected.accumulationMode === 'accumulated'}
+                    onChange={() => updateIndicator(selected.id, { accumulationMode: 'accumulated' })}
+                  />
+                  <span>Accumulated</span>
+                </label>
+              </div>
+            </div>
+
+            <button
+              className={styles.deleteButton}
+              onClick={() => { removeIndicator(selected.id); setSelectedId(null); }}
+            >
+              Delete Indicator
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TagOptionsEditor({ options, onChange }: { options: string[]; onChange: (opts: string[]) => void }) {
+  const [input, setInput] = useState('');
+  const add = () => {
+    const val = input.trim();
+    if (!val || options.includes(val)) return;
+    onChange([...options, val]);
+    setInput('');
+  };
+  return (
+    <div className={styles.field}>
+      <label className={styles.fieldLabel}>Tag Options</label>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
+        {options.map((opt, i) => (
+          <span
+            key={i}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3,
+              padding: '1px 8px', background: 'rgba(76,201,240,0.12)',
+              border: '1px solid rgba(76,201,240,0.25)', borderRadius: 10,
+              fontSize: '0.68rem', color: '#4cc9f0',
+            }}
+          >
+            {opt}
+            <button
+              onClick={() => onChange(options.filter((_, j) => j !== i))}
+              style={{
+                background: 'none', border: 'none', color: '#f44336',
+                cursor: 'pointer', fontSize: '0.7rem', padding: 0, lineHeight: 1,
+              }}
+            >x</button>
+          </span>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <input
+          className={styles.textInput}
+          style={{ flex: 1 }}
+          placeholder="Add option..."
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+        />
+        <button className={styles.addButton} style={{ padding: '2px 8px', flex: 'none' }} onClick={add}>+</button>
+      </div>
+    </div>
+  );
+}

--- a/src/modeler/panels/PropertiesPanelContent.tsx
+++ b/src/modeler/panels/PropertiesPanelContent.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useModel } from '../../model/ModelContext';
 import type { BoundaryTreatment, UpdateMode, AsyncScheme } from '../../model/types';
+import { IndicatorsPanelSection } from './IndicatorsPanelSection';
 import styles from './PanelContent.module.css';
 
 export function PropertiesPanelContent() {
@@ -213,6 +214,8 @@ export function PropertiesPanelContent() {
           )}
         </div>
       </div>
+
+      <IndicatorsPanelSection />
     </div>
   );
 }

--- a/src/modeler/vpl/CaNode.module.css
+++ b/src/modeler/vpl/CaNode.module.css
@@ -8,6 +8,10 @@
   position: relative;
 }
 
+.compactNode {
+  min-width: 80px;
+}
+
 .userLabel {
   padding: 3px 10px;
   font-size: 0.65rem;

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -162,6 +162,11 @@ function CaNodeComponent({ id, data }: NodeProps) {
     );
   }
 
+  // LogicOperator: hide port B when operation is NOT (unary)
+  if (nodeData.nodeType === 'logicOperator' && nodeData.config.operation === 'NOT') {
+    inputPorts = inputPorts.filter(p => p.id !== 'b');
+  }
+
   // Detect which input ports are connected (for inline widget visibility)
   const connectedInputHandles = useStore(
     useCallback(
@@ -309,9 +314,11 @@ function CaNodeComponent({ id, data }: NodeProps) {
     );
   }
 
+  const isCompact = nodeData.nodeType === 'step';
+
   return (
     <div
-      className={styles.node}
+      className={`${styles.node} ${isCompact ? styles.compactNode : ''}`}
       style={{ borderColor: def.color, minHeight: nodeMinHeight }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -251,6 +251,15 @@ function CaNodeComponent({ id, data }: NodeProps) {
     } else if (nodeData.nodeType === 'outputMapping') {
       const mapping = model.mappings.find(m => m.id === nodeData.config.mappingId);
       collapsedLabel = mapping ? `A\u2192C: ${mapping.name}` : def.label;
+    } else if (nodeData.nodeType === 'getIndicator') {
+      const ind = (model.indicators || []).find(i => i.id === nodeData.config.indicatorId);
+      collapsedLabel = ind ? `Ind - ${ind.name}` : def.label;
+    } else if (nodeData.nodeType === 'setIndicator') {
+      const ind = (model.indicators || []).find(i => i.id === nodeData.config.indicatorId);
+      collapsedLabel = ind ? `Set Ind - ${ind.name}` : def.label;
+    } else if (nodeData.nodeType === 'updateIndicator') {
+      const ind = (model.indicators || []).find(i => i.id === nodeData.config.indicatorId);
+      collapsedLabel = ind ? `Upd Ind - ${ind.name}` : def.label;
     } else {
       collapsedLabel = def.label;
     }
@@ -495,6 +504,67 @@ function CaNodeComponent({ id, data }: NodeProps) {
               ))}
           </select>
         )}
+
+        {(nodeData.nodeType === 'getIndicator' || nodeData.nodeType === 'setIndicator') && (
+          <select
+            className={styles.select}
+            value={(nodeData.config.indicatorId as string) || ''}
+            onChange={e => updateConfig('indicatorId', e.target.value)}
+          >
+            <option value="">Select...</option>
+            {(model.indicators || [])
+              .filter(i => i.kind === 'standalone')
+              .map(i => (
+                <option key={i.id} value={i.id}>{i.name}</option>
+              ))}
+          </select>
+        )}
+
+        {nodeData.nodeType === 'updateIndicator' && (() => {
+          const selInd = (model.indicators || []).find(i => i.id === nodeData.config.indicatorId);
+          const dt = selInd?.dataType || 'integer';
+          const opsByType: Record<string, Array<{ value: string; label: string }>> = {
+            bool: [{ value: 'toggle', label: 'Toggle' }, { value: 'or', label: 'OR' }, { value: 'and', label: 'AND' }],
+            integer: [{ value: 'increment', label: 'Increment (+)' }, { value: 'decrement', label: 'Decrement (-)' }, { value: 'max', label: 'Max' }, { value: 'min', label: 'Min' }],
+            float: [{ value: 'increment', label: 'Increment (+)' }, { value: 'decrement', label: 'Decrement (-)' }, { value: 'max', label: 'Max' }, { value: 'min', label: 'Min' }],
+            tag: [{ value: 'next', label: 'Next' }, { value: 'previous', label: 'Previous' }],
+          };
+          const ops = opsByType[dt] ?? opsByType.integer!;
+          return (
+            <>
+              <select
+                className={styles.select}
+                value={(nodeData.config.indicatorId as string) || ''}
+                onChange={e => {
+                  const ind = (model.indicators || []).find(i => i.id === e.target.value);
+                  const newDt = ind?.dataType || 'integer';
+                  const firstOp = (opsByType[newDt] ?? opsByType.integer)![0]!.value;
+                  const newConfig: NodeConfig = { ...nodeData.config, indicatorId: e.target.value, operation: firstOp };
+                  if (newDt === 'tag' && ind?.tagOptions) {
+                    newConfig._tagLen = ind.tagOptions.length;
+                  }
+                  updateNodeData(id, { ...nodeData, config: newConfig });
+                }}
+              >
+                <option value="">Select...</option>
+                {(model.indicators || [])
+                  .filter(i => i.kind === 'standalone')
+                  .map(i => (
+                    <option key={i.id} value={i.id}>{i.name}</option>
+                  ))}
+              </select>
+              <select
+                className={styles.select}
+                value={(nodeData.config.operation as string) || ops![0]!.value}
+                onChange={e => updateConfig('operation', e.target.value)}
+              >
+                {ops!.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </>
+          );
+        })()}
 
         {nodeData.nodeType === 'setColorViewer' && (() => {
           const allRgbConnected =

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -234,7 +234,7 @@ function CaNodeComponent({ id, data }: NodeProps) {
     } else if (nodeData.nodeType === 'setAttribute') {
       const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
       collapsedLabel = attr ? `Set - ${attr.name}` : def.label;
-    } else if (nodeData.nodeType === 'getNeighborsAttribute' || nodeData.nodeType === 'getNeighborAttributeByIndex') {
+    } else if (nodeData.nodeType === 'getNeighborsAttribute' || nodeData.nodeType === 'getNeighborAttributeByIndex' || nodeData.nodeType === 'getNeighborsAttrByIndexes') {
       const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
       const nbr = model.neighborhoods.find(n => n.id === nodeData.config.neighborhoodId);
       collapsedLabel = attr && nbr ? `${nbr.name}[${attr.name}]` : def.label;
@@ -348,6 +348,7 @@ function CaNodeComponent({ id, data }: NodeProps) {
 
         {(nodeData.nodeType === 'getNeighborsAttribute'
           || nodeData.nodeType === 'getNeighborAttributeByIndex'
+          || nodeData.nodeType === 'getNeighborsAttrByIndexes'
           || nodeData.nodeType === 'setNeighborhoodAttribute'
           || nodeData.nodeType === 'setNeighborAttributeByIndex') && (
           <>

--- a/src/modeler/vpl/GraphEditor.tsx
+++ b/src/modeler/vpl/GraphEditor.tsx
@@ -238,17 +238,24 @@ export function GraphEditorInner() {
       // Prevent flow↔value cross-category connections
       if (srcParsed.category !== tgtParsed.category) return false;
 
+      const currentEdges = edgesRef.current;
+
       // Prevent connecting to an already-connected value input
       if (tgtParsed.category === 'value') {
-        const currentEdges = edgesRef.current;
         const alreadyConnected = currentEdges.some(
           e => e.target === connection.target && e.targetHandle === connection.targetHandle,
         );
         if (alreadyConnected) return false;
       }
 
+      // Prevent duplicate connections (same source+target+handles)
+      const hasDuplicate = currentEdges.some(
+        e => e.source === connection.source && e.sourceHandle === connection.sourceHandle
+          && e.target === connection.target && e.targetHandle === connection.targetHandle,
+      );
+      if (hasDuplicate) return false;
+
       // Cycle detection: BFS from target to see if it can reach source
-      const currentEdges = edgesRef.current;
       const visited = new Set<string>();
       const queue = [connection.target!];
       while (queue.length > 0) {
@@ -472,6 +479,13 @@ export function GraphEditorInner() {
       if (!contextMenu) return;
       const def = getNodeDef(nodeType);
       if (!def) return;
+      // Singleton: only one Step node allowed
+      if (nodeType === 'step') {
+        const hasStep = nodesRef.current.some(
+          n => (n.data as Record<string, unknown>)?.nodeType === 'step',
+        );
+        if (hasStep) { setContextMenu(null); return; }
+      }
       pushCurrentSnapshot();
       setNodes(nds => {
         const id = generateNodeId(nds);
@@ -494,6 +508,9 @@ export function GraphEditorInner() {
     const targetNodeId = contextMenu.target.type === 'node' ? contextMenu.target.nodeId : '';
     const sourceNode = nodes.find(n => n.id === targetNodeId);
     if (!sourceNode) return;
+    // Singleton: don't duplicate Step nodes
+    const srcType = (sourceNode.data as Record<string, unknown>)?.nodeType;
+    if (srcType === 'step') { setContextMenu(null); return; }
     pushCurrentSnapshot();
     setNodes(nds => {
       const id = generateNodeId(nds);
@@ -556,6 +573,17 @@ export function GraphEditorInner() {
 
   const handlePaste = useCallback(() => {
     if (!clipboard || clipboard.nodes.length === 0) return;
+    // Singleton: filter out Step nodes if one already exists in the graph
+    const hasStepInGraph = nodesRef.current.some(
+      n => (n.data as Record<string, unknown>)?.nodeType === 'step',
+    );
+    if (hasStepInGraph) {
+      clipboard = {
+        nodes: clipboard.nodes.filter(n => (n.data as Record<string, unknown>)?.nodeType !== 'step'),
+        edges: clipboard.edges,
+      };
+      if (clipboard.nodes.length === 0) return;
+    }
     pushCurrentSnapshot();
 
     // Compute clipboard bounding-box center (top-level nodes only)

--- a/src/modeler/vpl/GroupNodeComponent.tsx
+++ b/src/modeler/vpl/GroupNodeComponent.tsx
@@ -29,8 +29,8 @@ function GroupNodeInner({ id, data, selected }: NodeProps) {
         isVisible={!!selected}
         minWidth={100}
         minHeight={60}
-        lineStyle={{ borderColor: color }}
-        handleStyle={{ width: 8, height: 8, background: color, borderRadius: 2 }}
+        lineStyle={{ borderColor: color, pointerEvents: 'auto' }}
+        handleStyle={{ width: 8, height: 8, background: color, borderRadius: 2, pointerEvents: 'auto' }}
       />
       <div className={styles.header} data-drag-handle>
         <input

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -207,6 +207,12 @@ function compileRoot(
         const nbrId = iNode.data.config.neighborhoodId as string || '_undef';
         scratchNodes.push({ scratchVarName: `${prefix}_scr_${innerNodeId}`, nbrId });
       }
+      if (nt === 'groupStatement' || nt === 'groupCounting') {
+        scratchNodes.push({ scratchVarName: `${prefix}_v${innerNodeId}_indexes`, initExpr: '[]' });
+      }
+      if (nt === 'getNeighborsAttrByIndexes') {
+        scratchNodes.push({ scratchVarName: `${prefix}_v${innerNodeId}_vals`, initExpr: '[]' });
+      }
 
       // Resolve inputs
       const iInputVars: Record<string, string> = {};
@@ -228,7 +234,12 @@ function compileRoot(
       const code = iDef.compile(innerNodeId, iNode.data.config, iInputVars);
       if (code) {
         // Rewrite variable names in emitted code to use scoped prefix
+        // Note: multi-output vars use _v{id}_{port} — the trailing _ breaks \b, so we
+        // also replace _v{id}_ (with trailing underscore) before the word-boundary version.
         const scopedCode = code.replace(
+          new RegExp(`\\b_v${innerNodeId}_`, 'g'),
+          `${prefix}_v${innerNodeId}_`,
+        ).replace(
           new RegExp(`\\b_v${innerNodeId}\\b`, 'g'),
           `${prefix}_v${innerNodeId}`,
         ).replace(
@@ -344,6 +355,12 @@ function compileRoot(
         const nbrId = iNode.data.config.neighborhoodId as string || '_undef';
         scratchNodes.push({ scratchVarName: `${nestedPrefix}_scr_${nid}`, nbrId });
       }
+      if (nt === 'groupStatement' || nt === 'groupCounting') {
+        scratchNodes.push({ scratchVarName: `${nestedPrefix}_v${nid}_indexes`, initExpr: '[]' });
+      }
+      if (nt === 'getNeighborsAttrByIndexes') {
+        scratchNodes.push({ scratchVarName: `${nestedPrefix}_v${nid}_vals`, initExpr: '[]' });
+      }
       const iInputVars: Record<string, string> = {};
       for (const port of iDef.ports) {
         if (port.kind !== 'input' || port.category !== 'value') continue;
@@ -362,6 +379,7 @@ function compileRoot(
       const code = iDef.compile(nid, iNode.data.config, iInputVars);
       if (code) {
         const scopedCode = code
+          .replace(new RegExp(`\\b_v${nid}_`, 'g'), `${nestedPrefix}_v${nid}_`)
           .replace(new RegExp(`\\b_v${nid}\\b`, 'g'), `${nestedPrefix}_v${nid}`)
           .replace(new RegExp(`\\b_scr_${nid}\\b`, 'g'), `${nestedPrefix}_scr_${nid}`)
           .replace(new RegExp(`\\b_nb${nid}\\b`, 'g'), `${nestedPrefix}_nb${nid}`);

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -777,79 +777,68 @@ function buildLinkedIndicatorCode(model: CAModel): {
   inLoopLines: string[];
   postLoopLines: string[];
 } {
-  const preLoopDecls: string[] = [];
-  const inLoopLines: string[] = [];
   const postLoopLines: string[] = [];
 
   const watched = (model.indicators || []).filter(
     i => i.kind === 'linked' && i.watched && i.linkedAttributeId,
   );
-  if (watched.length === 0) return { preLoopDecls, inLoopLines, postLoopLines };
+  if (watched.length === 0) return { preLoopDecls: [], inLoopLines: [], postLoopLines };
 
+  // All linked indicators are computed as post-loop passes over the final buffer.
+  // This is correct for both sync mode (w_ has new values after loop) and async mode
+  // (single buffer is fully updated). A separate pass over a typed array is fast
+  // (sequential memory scan, perfect cache locality) and avoids the async-mode bug
+  // where mid-loop aggregation sees a mix of old and new values.
   for (const ind of watched) {
     const attr = model.attributes.find(a => a.id === ind.linkedAttributeId);
     if (!attr || attr.isModelAttribute) continue;
-
-    const safe = ind.id.replace(/[^a-zA-Z0-9_]/g, '_');
-    const wVar = `w_${attr.id}`;  // read from write buffer (post-update values)
+    const wVar = `w_${attr.id}`;
     const key = JSON.stringify(ind.id);
 
     if (ind.linkedAggregation === 'total') {
-      // Sum all cell values
-      preLoopDecls.push(`  let _lnk_${safe} = 0;`);
-      inLoopLines.push(`      _lnk_${safe} += ${wVar}[idx];`);
-      postLoopLines.push(`  _linkedResults[${key}] = _lnk_${safe};`);
-
+      postLoopLines.push(
+        `  { let _s = 0; for (let _i = 0; _i < total; _i++) _s += ${wVar}[_i];` +
+        ` _linkedResults[${key}] = _s; }`,
+      );
     } else if (attr.type === 'bool') {
-      // Count true values; false = total - true
-      preLoopDecls.push(`  let _lnk_${safe}_t = 0;`);
-      inLoopLines.push(`      if (${wVar}[idx]) _lnk_${safe}_t++;`);
-      postLoopLines.push(`  _linkedResults[${key}] = { 'true': _lnk_${safe}_t, 'false': total - _lnk_${safe}_t };`);
-
+      postLoopLines.push(
+        `  { let _t = 0; for (let _i = 0; _i < total; _i++) if (${wVar}[_i]) _t++;` +
+        ` _linkedResults[${key}] = { 'true': _t, 'false': total - _t }; }`,
+      );
     } else if (attr.type === 'tag') {
       const tagLen = attr.tagOptions?.length || 1;
       const tagNames = JSON.stringify(attr.tagOptions || []);
-      preLoopDecls.push(`  const _lnk_${safe} = new Int32Array(${tagLen});`);
-      inLoopLines.push(`      _lnk_${safe}[${wVar}[idx]]++;`);
       postLoopLines.push(
-        `  { const _tn = ${tagNames}; const _f = {};` +
-        ` for (let _ti = 0; _ti < ${tagLen}; _ti++) _f[_tn[_ti]] = _lnk_${safe}[_ti];` +
+        `  { const _c = new Int32Array(${tagLen});` +
+        ` for (let _i = 0; _i < total; _i++) _c[${wVar}[_i]]++;` +
+        ` const _tn = ${tagNames}; const _f = {};` +
+        ` for (let _ti = 0; _ti < ${tagLen}; _ti++) _f[_tn[_ti]] = _c[_ti];` +
         ` _linkedResults[${key}] = _f; }`,
       );
-
     } else if (attr.type === 'integer') {
-      // Count per distinct value
-      preLoopDecls.push(`  const _lnk_${safe} = {};`);
-      inLoopLines.push(`      { const _k = ${wVar}[idx]; _lnk_${safe}[_k] = (_lnk_${safe}[_k] || 0) + 1; }`);
-      postLoopLines.push(`  _linkedResults[${key}] = _lnk_${safe};`);
-
-    } else if (attr.type === 'float') {
-      // Single-pass min/max in main loop, second pass for binning after loop
-      const bc = ind.binCount || 10;
-      preLoopDecls.push(`  let _lnk_${safe}_min = Infinity, _lnk_${safe}_max = -Infinity;`);
-      inLoopLines.push(
-        `      { const _v = ${wVar}[idx];` +
-        ` if (_v < _lnk_${safe}_min) _lnk_${safe}_min = _v;` +
-        ` if (_v > _lnk_${safe}_max) _lnk_${safe}_max = _v; }`,
-      );
       postLoopLines.push(
-        `  { const _bc = ${bc};` +
-        ` if (_lnk_${safe}_min === _lnk_${safe}_max) _lnk_${safe}_max = _lnk_${safe}_min + 1;` +
-        ` const _bw = (_lnk_${safe}_max - _lnk_${safe}_min) / _bc;` +
-        ` const _bins = new Int32Array(_bc);` +
-        ` for (let _bi = 0; _bi < total; _bi++)` +
-        ` { let _b = (${wVar}[_bi] - _lnk_${safe}_min) / _bw | 0; if (_b >= _bc) _b = _bc - 1; _bins[_b]++; }` +
+        `  { const _f = {};` +
+        ` for (let _i = 0; _i < total; _i++) { const _k = ${wVar}[_i]; _f[_k] = (_f[_k] || 0) + 1; }` +
+        ` _linkedResults[${key}] = _f; }`,
+      );
+    } else if (attr.type === 'float') {
+      const bc = ind.binCount || 10;
+      postLoopLines.push(
+        `  { let _mn = Infinity, _mx = -Infinity;` +
+        ` for (let _i = 0; _i < total; _i++) { const _v = ${wVar}[_i]; if (_v < _mn) _mn = _v; if (_v > _mx) _mx = _v; }` +
+        ` if (_mn === _mx) _mx = _mn + 1;` +
+        ` const _bw = (_mx - _mn) / ${bc}; const _bins = new Int32Array(${bc});` +
+        ` for (let _i = 0; _i < total; _i++) { let _b = (${wVar}[_i] - _mn) / _bw | 0; if (_b >= ${bc}) _b = ${bc - 1}; _bins[_b]++; }` +
         ` const _f = {};` +
-        ` for (let _bi = 0; _bi < _bc; _bi++)` +
-        ` { const _lo = (_lnk_${safe}_min + _bi * _bw).toFixed(2);` +
-        ` const _hi = (_lnk_${safe}_min + (_bi + 1) * _bw).toFixed(2);` +
+        ` for (let _bi = 0; _bi < ${bc}; _bi++)` +
+        ` { const _lo = (_mn + _bi * _bw).toFixed(2); const _hi = (_mn + (_bi + 1) * _bw).toFixed(2);` +
         ` _f[_lo + '\\u2013' + _hi] = _bins[_bi]; }` +
         ` _linkedResults[${key}] = _f; }`,
       );
     }
   }
 
-  return { preLoopDecls, inLoopLines, postLoopLines };
+  return { preLoopDecls: [], inLoopLines: [], postLoopLines };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -436,8 +436,15 @@ function compileRoot(
       const nbrId = node.data.config.neighborhoodId as string || '_undef';
       scratchNodes.push({ scratchVarName: `_scr_${nodeId}`, nbrId });
     }
-    // Track aggregation nodes that need reusable scratch arrays
+    // Track aggregation nodes that need reusable scratch arrays (only when indexes output is connected)
+    let needsIndexes = false;
     if (node.data.nodeType === 'groupStatement' || node.data.nodeType === 'groupCounting') {
+      // Check if any downstream node reads the indexes output
+      for (const [, src] of inputToSource) {
+        if (src.nodeId === nodeId && src.portId === 'indexes') { needsIndexes = true; break; }
+      }
+    }
+    if (needsIndexes) {
       scratchNodes.push({ scratchVarName: `_v${nodeId}_indexes`, initExpr: '[]' });
     }
     if (node.data.nodeType === 'getNeighborsAttrByIndexes') {
@@ -457,7 +464,11 @@ function compileRoot(
       }
     }
 
-    const code = def.compile(nodeId, node.data.config, inputVars);
+    // For aggregation nodes, pass whether indexes output is connected (for optimization)
+    const compileConfig = (node.data.nodeType === 'groupStatement' || node.data.nodeType === 'groupCounting')
+      ? { ...node.data.config, _indexesConnected: needsIndexes }
+      : node.data.config;
+    const code = def.compile(nodeId, compileConfig, inputVars);
     if (code) valueLines.push('      ' + code.trimEnd());
 
     return `_v${nodeId}`;
@@ -739,7 +750,7 @@ function buildLoopParams(model: CAModel): {
   for (const a of cellAttrs) parts.push(`r_${a.id}`);
   for (const a of cellAttrs) parts.push(`w_${a.id}`);
   for (const n of neighborhoods) { parts.push(`nIdx_${n.id}`); parts.push(`nSz_${n.id}`); }
-  parts.push('modelAttrs', 'colors', 'activeViewer');
+  parts.push('modelAttrs', 'colors', 'activeViewer', '_indicators', '_linkedResults');
   if (isAsync) parts.push('order');
 
   return { params: parts.join(', '), cellAttrs, neighborhoods };
@@ -753,8 +764,92 @@ function buildCellParams(model: CAModel): string {
   for (const a of cellAttrs) parts.push(`r_${a.id}`);
   for (const a of cellAttrs) parts.push(`w_${a.id}`);
   for (const n of neighborhoods) { parts.push(`nIdx_${n.id}`); parts.push(`nSz_${n.id}`); }
-  parts.push('modelAttrs', 'colors', 'activeViewer');
+  parts.push('modelAttrs', 'colors', 'activeViewer', '_indicators', '_linkedResults');
   return parts.join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// Linked indicator code generation (injected into step function)
+// ---------------------------------------------------------------------------
+
+function buildLinkedIndicatorCode(model: CAModel): {
+  preLoopDecls: string[];
+  inLoopLines: string[];
+  postLoopLines: string[];
+} {
+  const preLoopDecls: string[] = [];
+  const inLoopLines: string[] = [];
+  const postLoopLines: string[] = [];
+
+  const watched = (model.indicators || []).filter(
+    i => i.kind === 'linked' && i.watched && i.linkedAttributeId,
+  );
+  if (watched.length === 0) return { preLoopDecls, inLoopLines, postLoopLines };
+
+  for (const ind of watched) {
+    const attr = model.attributes.find(a => a.id === ind.linkedAttributeId);
+    if (!attr || attr.isModelAttribute) continue;
+
+    const safe = ind.id.replace(/[^a-zA-Z0-9_]/g, '_');
+    const wVar = `w_${attr.id}`;  // read from write buffer (post-update values)
+    const key = JSON.stringify(ind.id);
+
+    if (ind.linkedAggregation === 'total') {
+      // Sum all cell values
+      preLoopDecls.push(`  let _lnk_${safe} = 0;`);
+      inLoopLines.push(`      _lnk_${safe} += ${wVar}[idx];`);
+      postLoopLines.push(`  _linkedResults[${key}] = _lnk_${safe};`);
+
+    } else if (attr.type === 'bool') {
+      // Count true values; false = total - true
+      preLoopDecls.push(`  let _lnk_${safe}_t = 0;`);
+      inLoopLines.push(`      if (${wVar}[idx]) _lnk_${safe}_t++;`);
+      postLoopLines.push(`  _linkedResults[${key}] = { 'true': _lnk_${safe}_t, 'false': total - _lnk_${safe}_t };`);
+
+    } else if (attr.type === 'tag') {
+      const tagLen = attr.tagOptions?.length || 1;
+      const tagNames = JSON.stringify(attr.tagOptions || []);
+      preLoopDecls.push(`  const _lnk_${safe} = new Int32Array(${tagLen});`);
+      inLoopLines.push(`      _lnk_${safe}[${wVar}[idx]]++;`);
+      postLoopLines.push(
+        `  { const _tn = ${tagNames}; const _f = {};` +
+        ` for (let _ti = 0; _ti < ${tagLen}; _ti++) _f[_tn[_ti]] = _lnk_${safe}[_ti];` +
+        ` _linkedResults[${key}] = _f; }`,
+      );
+
+    } else if (attr.type === 'integer') {
+      // Count per distinct value
+      preLoopDecls.push(`  const _lnk_${safe} = {};`);
+      inLoopLines.push(`      { const _k = ${wVar}[idx]; _lnk_${safe}[_k] = (_lnk_${safe}[_k] || 0) + 1; }`);
+      postLoopLines.push(`  _linkedResults[${key}] = _lnk_${safe};`);
+
+    } else if (attr.type === 'float') {
+      // Single-pass min/max in main loop, second pass for binning after loop
+      const bc = ind.binCount || 10;
+      preLoopDecls.push(`  let _lnk_${safe}_min = Infinity, _lnk_${safe}_max = -Infinity;`);
+      inLoopLines.push(
+        `      { const _v = ${wVar}[idx];` +
+        ` if (_v < _lnk_${safe}_min) _lnk_${safe}_min = _v;` +
+        ` if (_v > _lnk_${safe}_max) _lnk_${safe}_max = _v; }`,
+      );
+      postLoopLines.push(
+        `  { const _bc = ${bc};` +
+        ` if (_lnk_${safe}_min === _lnk_${safe}_max) _lnk_${safe}_max = _lnk_${safe}_min + 1;` +
+        ` const _bw = (_lnk_${safe}_max - _lnk_${safe}_min) / _bc;` +
+        ` const _bins = new Int32Array(_bc);` +
+        ` for (let _bi = 0; _bi < total; _bi++)` +
+        ` { let _b = (${wVar}[_bi] - _lnk_${safe}_min) / _bw | 0; if (_b >= _bc) _b = _bc - 1; _bins[_b]++; }` +
+        ` const _f = {};` +
+        ` for (let _bi = 0; _bi < _bc; _bi++)` +
+        ` { const _lo = (_lnk_${safe}_min + _bi * _bw).toFixed(2);` +
+        ` const _hi = (_lnk_${safe}_min + (_bi + 1) * _bw).toFixed(2);` +
+        ` _f[_lo + '\\u2013' + _hi] = _bins[_bi]; }` +
+        ` _linkedResults[${key}] = _f; }`,
+      );
+    }
+  }
+
+  return { preLoopDecls, inLoopLines, postLoopLines };
 }
 
 // ---------------------------------------------------------------------------
@@ -821,11 +916,15 @@ export function compileGraph(
         : `  const ${s.scratchVarName} = ${s.initExpr ?? '[]'};`,
     );
 
+    // Build linked indicator aggregation code (injected into the loop)
+    const linked = buildLinkedIndicatorCode(model);
+
     if (isAsync) {
       // Async mode: iterate cells via shuffled order array
       stepCode = [
         `(function(${loopParams}) {`,
         ...scratchDecls,
+        ...linked.preLoopDecls,
         '  for (let _i = 0; _i < total; _i++) {',
         '    const idx = order[_i];',
         '    const colorIdx = idx * 4;',
@@ -833,21 +932,26 @@ export function compileGraph(
         ...valueLines,
         '',
         ...flowLines,
+        ...linked.inLoopLines,
         '  }',
+        ...linked.postLoopLines,
         '})',
       ].join('\n');
     } else {
-      // Sync mode: sequential iteration (unchanged)
+      // Sync mode: sequential iteration
       stepCode = [
         `(function(${loopParams}) {`,
         ...scratchDecls,
+        ...linked.preLoopDecls,
         '  for (let idx = 0; idx < total; idx++) {',
         '    const colorIdx = idx * 4;',
         ...copyLines,
         ...valueLines,
         '',
         ...flowLines,
+        ...linked.inLoopLines,
         '  }',
+        ...linked.postLoopLines,
         '})',
       ].join('\n');
     }
@@ -888,7 +992,7 @@ export function compileGraph(
   for (const a of cellAttrs) omParamParts.push(`w_${a.id}`);
   const neighborhoods = model.neighborhoods.map(n => ({ id: n.id }));
   for (const n of neighborhoods) { omParamParts.push(`nIdx_${n.id}`); omParamParts.push(`nSz_${n.id}`); }
-  omParamParts.push('modelAttrs', 'colors', 'activeViewer');
+  omParamParts.push('modelAttrs', 'colors', 'activeViewer', '_indicators', '_linkedResults');
   const omParams = omParamParts.join(', ');
 
   for (const omNode of outputMappingNodes) {

--- a/src/modeler/vpl/compiler/compile.ts
+++ b/src/modeler/vpl/compiler/compile.ts
@@ -66,15 +66,18 @@ const MULTI_OUTPUT_TYPES = new Set(['inputColor', 'getColorConstant', 'macro']);
 function isMultiOutput(data: { nodeType: string; config: Record<string, string | number | boolean> }): boolean {
   if (MULTI_OUTPUT_TYPES.has(data.nodeType)) return true;
   if (data.nodeType === 'getModelAttribute' && data.config.isColorAttr) return true;
+  if (data.nodeType === 'groupStatement' || data.nodeType === 'groupCounting'
+    || data.nodeType === 'groupOperator') return true;
   return false;
 }
 
 interface RootCompileResult {
   valueLines: string[];
   flowLines: string[];
-  /** Node IDs that need scratch array declarations (GetNeighborsAttribute nodes).
-   *  scratchVarName is the full variable name (e.g., _scr_n123 or _mnABC_scr_n123). */
-  scratchNodes: Array<{ scratchVarName: string; nbrId: string }>;
+  /** Nodes that need pre-loop declarations.
+   *  nbrId: sized array for neighborhood scratch (GetNeighborsAttribute).
+   *  initExpr: literal init expression for reusable scratch (e.g., '[]'). */
+  scratchNodes: Array<{ scratchVarName: string; nbrId?: string; initExpr?: string }>;
 }
 
 function compileRoot(
@@ -87,7 +90,7 @@ function compileRoot(
 ): RootCompileResult {
   const compiled = new Set<string>();
   const valueLines: string[] = [];
-  const scratchNodes: Array<{ scratchVarName: string; nbrId: string }> = [];
+  const scratchNodes: Array<{ scratchVarName: string; nbrId?: string; initExpr?: string }> = [];
 
   function varName(sourceNodeId: string, sourcePortId: string): string {
     const sourceNode = nodeMap.get(sourceNodeId);
@@ -97,6 +100,10 @@ function compileRoot(
     // GetNeighborsAttribute uses _scr_ prefix for its scratch array
     if (sourceNode?.data.nodeType === 'getNeighborsAttribute') {
       return `_scr_${sourceNodeId}`;
+    }
+    // GetNeighborsAttrByIndexes uses _v{id}_vals scratch array
+    if (sourceNode?.data.nodeType === 'getNeighborsAttrByIndexes') {
+      return `_v${sourceNodeId}_vals`;
     }
     return `_v${sourceNodeId}`;
   }
@@ -410,6 +417,13 @@ function compileRoot(
     if (node.data.nodeType === 'getNeighborsAttribute') {
       const nbrId = node.data.config.neighborhoodId as string || '_undef';
       scratchNodes.push({ scratchVarName: `_scr_${nodeId}`, nbrId });
+    }
+    // Track aggregation nodes that need reusable scratch arrays
+    if (node.data.nodeType === 'groupStatement' || node.data.nodeType === 'groupCounting') {
+      scratchNodes.push({ scratchVarName: `_v${nodeId}_indexes`, initExpr: '[]' });
+    }
+    if (node.data.nodeType === 'getNeighborsAttrByIndexes') {
+      scratchNodes.push({ scratchVarName: `_v${nodeId}_vals`, initExpr: '[]' });
     }
 
     const inputVars: Record<string, string> = {};
@@ -784,7 +798,9 @@ export function compileGraph(
 
     // Scratch array declarations (before the loop)
     const scratchDecls = scratchNodes.map(
-      s => `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`,
+      s => s.nbrId
+        ? `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`
+        : `  const ${s.scratchVarName} = ${s.initExpr ?? '[]'};`,
     );
 
     if (isAsync) {
@@ -863,7 +879,9 @@ export function compileGraph(
       omNode, 'do', nodeMap, inputToSource, flowOutputToTargets, model,
     );
     const scratchDecls = scratchNodes.map(
-      s => `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`,
+      s => s.nbrId
+        ? `  const ${s.scratchVarName} = new Array(nSz_${s.nbrId});`
+        : `  const ${s.scratchVarName} = ${s.initExpr ?? '[]'};`,
     );
     const code = [
       `(function(${omParams}) {`,

--- a/src/modeler/vpl/nodes/GetIndicatorNode.ts
+++ b/src/modeler/vpl/nodes/GetIndicatorNode.ts
@@ -1,0 +1,16 @@
+import type { NodeTypeDef } from '../types';
+
+export const GetIndicatorNode: NodeTypeDef = {
+  type: 'getIndicator',
+  label: 'Get Indicator',
+  category: 'data',
+  color: '#00695c',
+  ports: [
+    { id: 'value', label: 'Value', kind: 'output', category: 'value', dataType: 'any' },
+  ],
+  defaultConfig: { indicatorId: '' },
+  compile: (nodeId, config) => {
+    const indId = config.indicatorId as string || '_undef';
+    return `const _v${nodeId} = _indicators[${JSON.stringify(indId)}];\n`;
+  },
+};

--- a/src/modeler/vpl/nodes/GetNeighborsAttrByIndexesNode.ts
+++ b/src/modeler/vpl/nodes/GetNeighborsAttrByIndexesNode.ts
@@ -15,10 +15,11 @@ export const GetNeighborsAttrByIndexesNode: NodeTypeDef = {
     const attr = config.attributeId as string || '_undef';
     const indexes = inputs['indexes'] || '[]';
     const ni = `_ni${nodeId}`;
+    const vl = `_v${nodeId}_valsLen`;
     return [
-      `_v${nodeId}_vals.length = 0;`,
+      `_v${nodeId}_vals.length = 0; let ${vl} = 0;`,
       `for (let ${ni} = 0; ${ni} < ${indexes}.length; ${ni}++) {`,
-      `  _v${nodeId}_vals.push(r_${attr}[nIdx_${nbrId}[idx * nSz_${nbrId} + ((${indexes}[${ni}]) | 0)]]);`,
+      `  _v${nodeId}_vals[${vl}++] = r_${attr}[nIdx_${nbrId}[idx * nSz_${nbrId} + ((${indexes}[${ni}]) | 0)]];`,
       `}`,
     ].join(' ') + '\n';
   },

--- a/src/modeler/vpl/nodes/GetNeighborsAttrByIndexesNode.ts
+++ b/src/modeler/vpl/nodes/GetNeighborsAttrByIndexesNode.ts
@@ -1,0 +1,25 @@
+import type { NodeTypeDef } from '../types';
+
+export const GetNeighborsAttrByIndexesNode: NodeTypeDef = {
+  type: 'getNeighborsAttrByIndexes',
+  label: 'Get Neighbors Attr By Indexes',
+  category: 'data',
+  color: '#b71c1c',
+  ports: [
+    { id: 'indexes', label: 'Indexes', kind: 'input', category: 'value', dataType: 'any', isArray: true },
+    { id: 'values', label: 'Values', kind: 'output', category: 'value', dataType: 'any', isArray: true },
+  ],
+  defaultConfig: { neighborhoodId: '', attributeId: '' },
+  compile: (nodeId, config, inputs) => {
+    const nbrId = config.neighborhoodId as string || '_undef';
+    const attr = config.attributeId as string || '_undef';
+    const indexes = inputs['indexes'] || '[]';
+    const ni = `_ni${nodeId}`;
+    return [
+      `_v${nodeId}_vals.length = 0;`,
+      `for (let ${ni} = 0; ${ni} < ${indexes}.length; ${ni}++) {`,
+      `  _v${nodeId}_vals.push(r_${attr}[nIdx_${nbrId}[idx * nSz_${nbrId} + ((${indexes}[${ni}]) | 0)]]);`,
+      `}`,
+    ].join(' ') + '\n';
+  },
+};

--- a/src/modeler/vpl/nodes/GroupCountingNode.ts
+++ b/src/modeler/vpl/nodes/GroupCountingNode.ts
@@ -9,19 +9,26 @@ export const GroupCountingNode: NodeTypeDef = {
     { id: 'values', label: 'Values', kind: 'input', category: 'value', dataType: 'any', isArray: true },
     { id: 'compare', label: 'Compare To', kind: 'input', category: 'value', dataType: 'any' },
     { id: 'count', label: 'Count', kind: 'output', category: 'value', dataType: 'integer' },
+    { id: 'indexes', label: 'Indexes', kind: 'output', category: 'value', dataType: 'any', isArray: true },
   ],
   defaultConfig: { operation: 'equals' },
   compile: (nodeId, config, inputs) => {
     const valuesVar = inputs['values'] || '[]';
     const compareVar = inputs['compare'] || '0';
     const op = config.operation as string;
+    const gi = `_gi${nodeId}`;
+    const elem = `${valuesVar}[${gi}]`;
     let cond: string;
     switch (op) {
-      case 'notEquals': cond = `v !== ${compareVar}`; break;
-      case 'greater':   cond = `v > ${compareVar}`; break;
-      case 'lesser':    cond = `v < ${compareVar}`; break;
-      default:          cond = `v === ${compareVar}`; break;
+      case 'notEquals': cond = `${elem} !== ${compareVar}`; break;
+      case 'greater':   cond = `${elem} > ${compareVar}`; break;
+      case 'lesser':    cond = `${elem} < ${compareVar}`; break;
+      default:          cond = `${elem} === ${compareVar}`; break;
     }
-    return `let _v${nodeId} = 0; for (let _i = 0; _i < ${valuesVar}.length; _i++) { const v = ${valuesVar}[_i]; if (${cond}) _v${nodeId}++; }\n`;
+    return [
+      `_v${nodeId}_indexes.length = 0;`,
+      `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+      `const _v${nodeId}_count = _v${nodeId}_indexes.length;`,
+    ].join(' ') + '\n';
   },
 };

--- a/src/modeler/vpl/nodes/GroupCountingNode.ts
+++ b/src/modeler/vpl/nodes/GroupCountingNode.ts
@@ -25,10 +25,21 @@ export const GroupCountingNode: NodeTypeDef = {
       case 'lesser':    cond = `${elem} < ${compareVar}`; break;
       default:          cond = `${elem} === ${compareVar}`; break;
     }
+    const needsIndexes = !!config._indexesConnected;
+
+    if (needsIndexes) {
+      // Full loop: collect matching indexes (when indexes output is connected)
+      return [
+        `_v${nodeId}_indexes.length = 0;`,
+        `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+        `const _v${nodeId}_count = _v${nodeId}_indexes.length;`,
+      ].join(' ') + '\n';
+    }
+
+    // Fast path: simple counter (no index tracking needed)
     return [
-      `_v${nodeId}_indexes.length = 0;`,
-      `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
-      `const _v${nodeId}_count = _v${nodeId}_indexes.length;`,
+      `let _v${nodeId}_count = 0;`,
+      `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_count++; }`,
     ].join(' ') + '\n';
   },
 };

--- a/src/modeler/vpl/nodes/GroupCountingNode.ts
+++ b/src/modeler/vpl/nodes/GroupCountingNode.ts
@@ -30,8 +30,8 @@ export const GroupCountingNode: NodeTypeDef = {
     if (needsIndexes) {
       // Full loop: collect matching indexes (when indexes output is connected)
       return [
-        `_v${nodeId}_indexes.length = 0;`,
-        `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+        `_v${nodeId}_indexes.length = 0; let _v${nodeId}_indexesLen = 0;`,
+        `for (let ${gi} = 0; ${gi} < ${valuesVar}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes[_v${nodeId}_indexesLen++] = ${gi}; }`,
         `const _v${nodeId}_count = _v${nodeId}_indexes.length;`,
       ].join(' ') + '\n';
     }

--- a/src/modeler/vpl/nodes/GroupOperatorNode.ts
+++ b/src/modeler/vpl/nodes/GroupOperatorNode.ts
@@ -8,22 +8,43 @@ export const GroupOperatorNode: NodeTypeDef = {
   ports: [
     { id: 'values', label: 'Values', kind: 'input', category: 'value', dataType: 'any', isArray: true },
     { id: 'result', label: 'Result', kind: 'output', category: 'value', dataType: 'any' },
+    { id: 'index', label: 'Index', kind: 'output', category: 'value', dataType: 'integer' },
   ],
   defaultConfig: { operation: 'sum' },
   compile: (nodeId, config, inputs) => {
     const values = inputs['values'] || '[]';
     const op = config.operation as string;
+    const gi = `_gi${nodeId}`;
+
+    if (op === 'random') {
+      return [
+        `const _v${nodeId}_index = Math.floor(Math.random() * ${values}.length);`,
+        `const _v${nodeId}_result = ${values}[_v${nodeId}_index];`,
+      ].join(' ') + '\n';
+    }
+    if (op === 'max') {
+      return [
+        `let _v${nodeId}_index = 0;`,
+        `for (let ${gi} = 1; ${gi} < ${values}.length; ${gi}++) { if (${values}[${gi}] > ${values}[_v${nodeId}_index]) _v${nodeId}_index = ${gi}; }`,
+        `const _v${nodeId}_result = ${values}[_v${nodeId}_index];`,
+      ].join(' ') + '\n';
+    }
+    if (op === 'min') {
+      return [
+        `let _v${nodeId}_index = 0;`,
+        `for (let ${gi} = 1; ${gi} < ${values}.length; ${gi}++) { if (${values}[${gi}] < ${values}[_v${nodeId}_index]) _v${nodeId}_index = ${gi}; }`,
+        `const _v${nodeId}_result = ${values}[_v${nodeId}_index];`,
+      ].join(' ') + '\n';
+    }
+
     let expr: string;
     switch (op) {
-      case 'mul':     expr = `${values}.reduce((s,v) => s * v, 1)`; break;
-      case 'max':     expr = `Math.max(...${values})`; break;
-      case 'min':     expr = `Math.min(...${values})`; break;
-      case 'mean':    expr = `(${values}.reduce((s,v) => s + v, 0) / (${values}.length || 1))`; break;
-      case 'and':     expr = `${values}.every(Boolean)`; break;
-      case 'or':      expr = `${values}.some(Boolean)`; break;
-      case 'random':  expr = `${values}[Math.floor(Math.random() * ${values}.length)]`; break;
-      default:        expr = `${values}.reduce((s,v) => s + v, 0)`; break; // sum
+      case 'mul':  expr = `${values}.reduce((s,v) => s * v, 1)`; break;
+      case 'mean': expr = `(${values}.reduce((s,v) => s + v, 0) / (${values}.length || 1))`; break;
+      case 'and':  expr = `${values}.every(Boolean)`; break;
+      case 'or':   expr = `${values}.some(Boolean)`; break;
+      default:     expr = `${values}.reduce((s,v) => s + v, 0)`; break; // sum
     }
-    return `const _v${nodeId} = ${expr};\n`;
+    return `const _v${nodeId}_index = -1; const _v${nodeId}_result = ${expr};\n`;
   },
 };

--- a/src/modeler/vpl/nodes/GroupStatementNode.ts
+++ b/src/modeler/vpl/nodes/GroupStatementNode.ts
@@ -9,22 +9,30 @@ export const GroupStatementNode: NodeTypeDef = {
     { id: 'values', label: 'Values', kind: 'input', category: 'value', dataType: 'any', isArray: true },
     { id: 'x', label: 'X', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
     { id: 'result', label: 'Result', kind: 'output', category: 'value', dataType: 'bool' },
+    { id: 'indexes', label: 'Indexes', kind: 'output', category: 'value', dataType: 'any', isArray: true },
   ],
   defaultConfig: { operation: 'allIs' },
   compile: (nodeId, config, inputs) => {
     const values = inputs['values'] || '[]';
     const x = inputs['x'] || '0';
     const op = config.operation as string;
-    let expr: string;
+    const gi = `_gi${nodeId}`;
+    const elem = `${values}[${gi}]`;
+    let cond: string;
     switch (op) {
-      case 'noneIs':     expr = `${values}.every(v => v !== ${x})`; break;
-      case 'hasA':       expr = `${values}.some(v => v === ${x})`; break;
-      case 'allGreater': expr = `${values}.every(v => v > ${x})`; break;
-      case 'allLesser':  expr = `${values}.every(v => v < ${x})`; break;
-      case 'anyGreater': expr = `${values}.some(v => v > ${x})`; break;
-      case 'anyLesser':  expr = `${values}.some(v => v < ${x})`; break;
-      default:           expr = `${values}.every(v => v === ${x})`; break; // allIs
+      case 'noneIs':                        cond = `${elem} !== ${x}`; break;
+      case 'allGreater': case 'anyGreater': cond = `${elem} > ${x}`; break;
+      case 'allLesser':  case 'anyLesser':  cond = `${elem} < ${x}`; break;
+      default:                              cond = `${elem} === ${x}`; break; // allIs, hasA
     }
-    return `const _v${nodeId} = ${expr};\n`;
+    const isAll = op === 'allIs' || op === 'noneIs' || op === 'allGreater' || op === 'allLesser';
+    const resultExpr = isAll
+      ? `_v${nodeId}_indexes.length === ${values}.length`
+      : `_v${nodeId}_indexes.length > 0`;
+    return [
+      `_v${nodeId}_indexes.length = 0;`,
+      `for (let ${gi} = 0; ${gi} < ${values}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+      `const _v${nodeId}_result = ${resultExpr};`,
+    ].join(' ') + '\n';
   },
 };

--- a/src/modeler/vpl/nodes/GroupStatementNode.ts
+++ b/src/modeler/vpl/nodes/GroupStatementNode.ts
@@ -7,7 +7,7 @@ export const GroupStatementNode: NodeTypeDef = {
   color: '#e65100',
   ports: [
     { id: 'values', label: 'Values', kind: 'input', category: 'value', dataType: 'any', isArray: true },
-    { id: 'x', label: 'X', kind: 'input', category: 'value', dataType: 'any' },
+    { id: 'x', label: 'X', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
     { id: 'result', label: 'Result', kind: 'output', category: 'value', dataType: 'bool' },
   ],
   defaultConfig: { operation: 'allIs' },

--- a/src/modeler/vpl/nodes/GroupStatementNode.ts
+++ b/src/modeler/vpl/nodes/GroupStatementNode.ts
@@ -16,23 +16,42 @@ export const GroupStatementNode: NodeTypeDef = {
     const values = inputs['values'] || '[]';
     const x = inputs['x'] || '0';
     const op = config.operation as string;
-    const gi = `_gi${nodeId}`;
-    const elem = `${values}[${gi}]`;
-    let cond: string;
-    switch (op) {
-      case 'noneIs':                        cond = `${elem} !== ${x}`; break;
-      case 'allGreater': case 'anyGreater': cond = `${elem} > ${x}`; break;
-      case 'allLesser':  case 'anyLesser':  cond = `${elem} < ${x}`; break;
-      default:                              cond = `${elem} === ${x}`; break; // allIs, hasA
-    }
     const isAll = op === 'allIs' || op === 'noneIs' || op === 'allGreater' || op === 'allLesser';
-    const resultExpr = isAll
-      ? `_v${nodeId}_indexes.length === ${values}.length`
-      : `_v${nodeId}_indexes.length > 0`;
-    return [
-      `_v${nodeId}_indexes.length = 0;`,
-      `for (let ${gi} = 0; ${gi} < ${values}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
-      `const _v${nodeId}_result = ${resultExpr};`,
-    ].join(' ') + '\n';
+    const needsIndexes = !!config._indexesConnected;
+
+    if (needsIndexes) {
+      // Full loop: collect matching indexes (when indexes output is connected)
+      const gi = `_gi${nodeId}`;
+      const elem = `${values}[${gi}]`;
+      let cond: string;
+      switch (op) {
+        case 'noneIs':                        cond = `${elem} !== ${x}`; break;
+        case 'allGreater': case 'anyGreater': cond = `${elem} > ${x}`; break;
+        case 'allLesser':  case 'anyLesser':  cond = `${elem} < ${x}`; break;
+        default:                              cond = `${elem} === ${x}`; break;
+      }
+      const resultExpr = isAll
+        ? `_v${nodeId}_indexes.length === ${values}.length`
+        : `_v${nodeId}_indexes.length > 0`;
+      return [
+        `_v${nodeId}_indexes.length = 0;`,
+        `for (let ${gi} = 0; ${gi} < ${values}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+        `const _v${nodeId}_result = ${resultExpr};`,
+      ].join(' ') + '\n';
+    }
+
+    // Fast path: short-circuit evaluation (no index tracking needed)
+    let expr: string;
+    switch (op) {
+      case 'allIs':      expr = `${values}.every(v => v === ${x})`; break;
+      case 'noneIs':     expr = `${values}.every(v => v !== ${x})`; break;
+      case 'hasA':       expr = `${values}.some(v => v === ${x})`; break;
+      case 'allGreater': expr = `${values}.every(v => v > ${x})`; break;
+      case 'anyGreater': expr = `${values}.some(v => v > ${x})`; break;
+      case 'allLesser':  expr = `${values}.every(v => v < ${x})`; break;
+      case 'anyLesser':  expr = `${values}.some(v => v < ${x})`; break;
+      default:           expr = `${values}.every(v => v === ${x})`; break;
+    }
+    return `const _v${nodeId}_result = ${expr};\n`;
   },
 };

--- a/src/modeler/vpl/nodes/GroupStatementNode.ts
+++ b/src/modeler/vpl/nodes/GroupStatementNode.ts
@@ -34,8 +34,8 @@ export const GroupStatementNode: NodeTypeDef = {
         ? `_v${nodeId}_indexes.length === ${values}.length`
         : `_v${nodeId}_indexes.length > 0`;
       return [
-        `_v${nodeId}_indexes.length = 0;`,
-        `for (let ${gi} = 0; ${gi} < ${values}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes.push(${gi}); }`,
+        `_v${nodeId}_indexes.length = 0; let _v${nodeId}_indexesLen = 0;`,
+        `for (let ${gi} = 0; ${gi} < ${values}.length; ${gi}++) { if (${cond}) _v${nodeId}_indexes[_v${nodeId}_indexesLen++] = ${gi}; }`,
         `const _v${nodeId}_result = ${resultExpr};`,
       ].join(' ') + '\n';
     }

--- a/src/modeler/vpl/nodes/SetIndicatorNode.ts
+++ b/src/modeler/vpl/nodes/SetIndicatorNode.ts
@@ -1,0 +1,19 @@
+import type { NodeTypeDef } from '../types';
+
+export const SetIndicatorNode: NodeTypeDef = {
+  type: 'setIndicator',
+  label: 'Set Indicator',
+  category: 'output',
+  color: '#00695c',
+  ports: [
+    { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
+    { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
+  ],
+  defaultConfig: { indicatorId: '' },
+  compile: (nodeId, config, inputs) => {
+    const indId = config.indicatorId as string || '_undef';
+    const value = inputs['value'] || '0';
+    void nodeId;
+    return `_indicators[${JSON.stringify(indId)}] = ${value};\n`;
+  },
+};

--- a/src/modeler/vpl/nodes/UpdateIndicatorNode.ts
+++ b/src/modeler/vpl/nodes/UpdateIndicatorNode.ts
@@ -1,0 +1,35 @@
+import type { NodeTypeDef } from '../types';
+
+export const UpdateIndicatorNode: NodeTypeDef = {
+  type: 'updateIndicator',
+  label: 'Update Indicator',
+  category: 'output',
+  color: '#00695c',
+  ports: [
+    { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
+    { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },
+  ],
+  defaultConfig: { indicatorId: '', operation: 'increment' },
+  compile: (nodeId, config, inputs) => {
+    const indId = config.indicatorId as string || '_undef';
+    const value = inputs['value'] || '0';
+    const op = config.operation as string;
+    const key = JSON.stringify(indId);
+    void nodeId;
+    switch (op) {
+      // Bool operations
+      case 'toggle': return `_indicators[${key}] = _indicators[${key}] ? 0 : 1;\n`;
+      case 'or':     return `_indicators[${key}] = (_indicators[${key}] || ${value}) ? 1 : 0;\n`;
+      case 'and':    return `_indicators[${key}] = (_indicators[${key}] && ${value}) ? 1 : 0;\n`;
+      // Integer/Float operations
+      case 'decrement': return `_indicators[${key}] -= ${value};\n`;
+      case 'max':       return `_indicators[${key}] = Math.max(_indicators[${key}], ${value});\n`;
+      case 'min':       return `_indicators[${key}] = Math.min(_indicators[${key}], ${value});\n`;
+      // Tag operations
+      case 'next':     return `_indicators[${key}] = (_indicators[${key}] + 1) % (${Number(config._tagLen) || 1});\n`;
+      case 'previous': return `_indicators[${key}] = (_indicators[${key}] - 1 + ${Number(config._tagLen) || 1}) % (${Number(config._tagLen) || 1});\n`;
+      // Default: increment (integer/float)
+      default: return `_indicators[${key}] += ${value};\n`;
+    }
+  },
+};

--- a/src/modeler/vpl/nodes/registry.ts
+++ b/src/modeler/vpl/nodes/registry.ts
@@ -27,6 +27,9 @@ import { GetNeighborAttributeByIndexNode } from './GetNeighborAttributeByIndexNo
 import { SetNeighborAttributeByIndexNode } from './SetNeighborAttributeByIndexNode';
 import { OutputMappingNode } from './OutputMappingNode';
 import { GetNeighborsAttrByIndexesNode } from './GetNeighborsAttrByIndexesNode';
+import { GetIndicatorNode } from './GetIndicatorNode';
+import { SetIndicatorNode } from './SetIndicatorNode';
+import { UpdateIndicatorNode } from './UpdateIndicatorNode';
 
 const ALL_NODES: NodeTypeDef[] = [
   // Event (entry points)
@@ -61,6 +64,10 @@ const ALL_NODES: NodeTypeDef[] = [
   // Color
   SetColorViewerNode,
   GetColorConstantNode,
+  // Indicators
+  GetIndicatorNode,
+  SetIndicatorNode,
+  UpdateIndicatorNode,
   // Macro
   MacroNode,
   MacroInputNode,

--- a/src/modeler/vpl/nodes/registry.ts
+++ b/src/modeler/vpl/nodes/registry.ts
@@ -26,6 +26,7 @@ import { SetNeighborhoodAttributeNode } from './SetNeighborhoodAttributeNode';
 import { GetNeighborAttributeByIndexNode } from './GetNeighborAttributeByIndexNode';
 import { SetNeighborAttributeByIndexNode } from './SetNeighborAttributeByIndexNode';
 import { OutputMappingNode } from './OutputMappingNode';
+import { GetNeighborsAttrByIndexesNode } from './GetNeighborsAttrByIndexesNode';
 
 const ALL_NODES: NodeTypeDef[] = [
   // Event (entry points)
@@ -41,6 +42,7 @@ const ALL_NODES: NodeTypeDef[] = [
   GetModelAttributeNode,
   GetNeighborsAttributeNode,
   GetNeighborAttributeByIndexNode,
+  GetNeighborsAttrByIndexesNode,
   GetConstantNode,
   GetRandomNode,
   TagConstantNode,

--- a/src/simulator/IndicatorDisplay.module.css
+++ b/src/simulator/IndicatorDisplay.module.css
@@ -41,6 +41,27 @@
   cursor: default;
 }
 
+.chartBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.5rem;
+  padding: 0;
+  line-height: 1;
+  color: #6080a0;
+  width: 14px;
+  text-align: center;
+  transition: color 0.15s;
+}
+
+.chartBtn:hover {
+  color: #4cc9f0;
+}
+
+.chartBtnActive {
+  color: #4cc9f0;
+}
+
 .name {
   font-size: 0.7rem;
   color: #e0e0e0;
@@ -69,12 +90,18 @@
   font-family: monospace;
 }
 
+.sparklineWrap {
+  margin-top: 4px;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
 .freqTable {
   margin-top: 4px;
   display: flex;
   flex-direction: column;
   gap: 1px;
-  max-height: 120px;
+  max-height: 160px;
   overflow-y: auto;
 }
 
@@ -83,6 +110,44 @@
   justify-content: space-between;
   font-size: 0.65rem;
   padding: 1px 4px 1px 20px;
+}
+
+/* Histogram bar row */
+.freqBarRow {
+  display: flex;
+  align-items: center;
+  font-size: 0.65rem;
+  padding: 1px 4px 1px 4px;
+  gap: 4px;
+}
+
+.freqBarRow .freqKey {
+  width: 40px;
+  min-width: 40px;
+  flex: none;
+}
+
+.freqBarTrack {
+  flex: 1;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.freqBar {
+  height: 100%;
+  background: rgba(76, 201, 240, 0.45);
+  border-radius: 2px;
+  min-width: 1px;
+  transition: width 0.1s ease-out;
+}
+
+.freqBarRow .freqCount {
+  width: 36px;
+  min-width: 36px;
+  flex: none;
+  text-align: right;
 }
 
 .freqKey {
@@ -96,6 +161,7 @@
 .freqCount {
   color: #4cc9f0;
   font-family: monospace;
+  font-size: 0.6rem;
   margin-left: 8px;
   flex-shrink: 0;
 }

--- a/src/simulator/IndicatorDisplay.module.css
+++ b/src/simulator/IndicatorDisplay.module.css
@@ -1,0 +1,101 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.indicator {
+  background: rgba(13, 17, 23, 0.5);
+  border: 1px solid #2d4059;
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.eyeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0;
+  line-height: 1;
+  color: #8090a0;
+  width: 16px;
+  text-align: center;
+}
+
+.eyeActive {
+  color: #4cc9f0;
+}
+
+.eyeDisabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.name {
+  font-size: 0.7rem;
+  color: #e0e0e0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  font-size: 0.55rem;
+  font-weight: 700;
+  color: #0d1117;
+  background: #4cc9f0;
+  border-radius: 3px;
+  padding: 0 3px;
+  line-height: 1.4;
+}
+
+.scalarValue {
+  font-size: 0.75rem;
+  color: #4cc9f0;
+  font-weight: 600;
+  margin-top: 2px;
+  padding-left: 20px;
+  font-family: monospace;
+}
+
+.freqTable {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.freqRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.65rem;
+  padding: 1px 4px 1px 20px;
+}
+
+.freqKey {
+  color: #b0b8c0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.freqCount {
+  color: #4cc9f0;
+  font-family: monospace;
+  margin-left: 8px;
+  flex-shrink: 0;
+}

--- a/src/simulator/IndicatorDisplay.tsx
+++ b/src/simulator/IndicatorDisplay.tsx
@@ -59,14 +59,15 @@ export function IndicatorDisplay({ indicators, values, history, generation, onTo
         return (
           <div key={ind.id} className={styles.indicator}>
             <div className={styles.header}>
-              <button
-                className={`${styles.eyeBtn} ${isWatched ? styles.eyeActive : ''} ${isStandalone ? styles.eyeDisabled : ''}`}
-                onClick={isStandalone ? undefined : () => onToggleWatch(ind.id, !isWatched)}
-                title={isStandalone ? 'Always active (computed by update graph)' : isWatched ? 'Unwatch (stop computing)' : 'Watch (start computing)'}
-                disabled={isStandalone}
-              >
-                {isWatched ? '\u{1F441}' : '\u25CB'}
-              </button>
+              {!isStandalone && (
+                <button
+                  className={`${styles.eyeBtn} ${isWatched ? styles.eyeActive : ''}`}
+                  onClick={() => onToggleWatch(ind.id, !isWatched)}
+                  title={isWatched ? 'Unwatch (stop computing)' : 'Watch (start computing)'}
+                >
+                  {isWatched ? '\u{1F441}' : '\u25CB'}
+                </button>
+              )}
               {isWatched && val !== undefined && (
                 <button
                   className={`${styles.chartBtn} ${isExpanded ? styles.chartBtnActive : ''}`}

--- a/src/simulator/IndicatorDisplay.tsx
+++ b/src/simulator/IndicatorDisplay.tsx
@@ -1,0 +1,66 @@
+import type { Indicator } from '../model/types';
+import styles from './IndicatorDisplay.module.css';
+
+interface Props {
+  indicators: Indicator[];
+  values: Record<string, number | Record<string, number>>;
+  onToggleWatch: (id: string, watched: boolean) => void;
+}
+
+function formatValue(val: number, ind: Indicator): string {
+  if (ind.dataType === 'bool') return val ? 'true' : 'false';
+  if (ind.dataType === 'tag' && ind.tagOptions) {
+    return ind.tagOptions[val] ?? `tag_${val}`;
+  }
+  if (ind.dataType === 'float') return val.toFixed(2);
+  return String(val);
+}
+
+export function IndicatorDisplay({ indicators, values, onToggleWatch }: Props) {
+  if (indicators.length === 0) return null;
+
+  return (
+    <div className={styles.container}>
+      {indicators.map(ind => {
+        const val = values[ind.id];
+        const isWatched = ind.watched;
+
+        const isStandalone = ind.kind === 'standalone';
+
+        return (
+          <div key={ind.id} className={styles.indicator}>
+            <div className={styles.header}>
+              <button
+                className={`${styles.eyeBtn} ${isWatched ? styles.eyeActive : ''} ${isStandalone ? styles.eyeDisabled : ''}`}
+                onClick={isStandalone ? undefined : () => onToggleWatch(ind.id, !isWatched)}
+                title={isStandalone ? 'Always active (computed by update graph)' : isWatched ? 'Unwatch (stop computing)' : 'Watch (start computing)'}
+                disabled={isStandalone}
+              >
+                {isWatched ? '\u{1F441}' : '\u25CB'}
+              </button>
+              <span className={styles.name}>{ind.name}</span>
+              <span className={styles.badge}>
+                {ind.kind === 'standalone' ? 'S' : 'L'}
+              </span>
+            </div>
+
+            {isWatched && val !== undefined && (
+              typeof val === 'number' ? (
+                <div className={styles.scalarValue}>{formatValue(val, ind)}</div>
+              ) : (
+                <div className={styles.freqTable}>
+                  {Object.entries(val).map(([k, count]) => (
+                    <div key={k} className={styles.freqRow}>
+                      <span className={styles.freqKey}>{k}</span>
+                      <span className={styles.freqCount}>{count}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/simulator/IndicatorDisplay.tsx
+++ b/src/simulator/IndicatorDisplay.tsx
@@ -1,10 +1,15 @@
+import { useState, useCallback, useEffect } from 'react';
 import type { Indicator } from '../model/types';
+import { IndicatorSparkline } from './IndicatorSparkline';
 import styles from './IndicatorDisplay.module.css';
 
 interface Props {
   indicators: Indicator[];
   values: Record<string, number | Record<string, number>>;
+  history: Record<string, number[]>;
+  generation: number;
   onToggleWatch: (id: string, watched: boolean) => void;
+  onChartToggle: (id: string, expanded: boolean) => void;
 }
 
 function formatValue(val: number, ind: Indicator): string {
@@ -16,7 +21,29 @@ function formatValue(val: number, ind: Indicator): string {
   return String(val);
 }
 
-export function IndicatorDisplay({ indicators, values, onToggleWatch }: Props) {
+export function IndicatorDisplay({ indicators, values, history, generation, onToggleWatch, onChartToggle }: Props) {
+  // Track *collapsed* IDs — everything is expanded by default
+  const [collapsedCharts, setCollapsedCharts] = useState<Set<string>>(new Set());
+
+  // Notify parent of all initially-expanded indicators (for history collection)
+  const indicatorIds = indicators.map(i => i.id).join(',');
+  useEffect(() => {
+    for (const ind of indicators) {
+      if (!collapsedCharts.has(ind.id)) onChartToggle(ind.id, true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [indicatorIds]);
+
+  const toggleChart = useCallback((id: string) => {
+    setCollapsedCharts(prev => {
+      const next = new Set(prev);
+      const wasCollapsed = next.has(id);
+      if (wasCollapsed) next.delete(id); else next.add(id);
+      onChartToggle(id, wasCollapsed); // wasCollapsed → now expanded
+      return next;
+    });
+  }, [onChartToggle]);
+
   if (indicators.length === 0) return null;
 
   return (
@@ -24,8 +51,10 @@ export function IndicatorDisplay({ indicators, values, onToggleWatch }: Props) {
       {indicators.map(ind => {
         const val = values[ind.id];
         const isWatched = ind.watched;
-
         const isStandalone = ind.kind === 'standalone';
+        const isExpanded = !collapsedCharts.has(ind.id);
+        const isScalar = val !== undefined && typeof val === 'number';
+        const isFreq = val !== undefined && typeof val === 'object';
 
         return (
           <div key={ind.id} className={styles.indicator}>
@@ -38,26 +67,67 @@ export function IndicatorDisplay({ indicators, values, onToggleWatch }: Props) {
               >
                 {isWatched ? '\u{1F441}' : '\u25CB'}
               </button>
+              {isWatched && val !== undefined && (
+                <button
+                  className={`${styles.chartBtn} ${isExpanded ? styles.chartBtnActive : ''}`}
+                  onClick={() => toggleChart(ind.id)}
+                  title={isExpanded ? 'Hide chart' : 'Show chart'}
+                >
+                  {isExpanded ? '\u25B2' : '\u25BC'}
+                </button>
+              )}
               <span className={styles.name}>{ind.name}</span>
               <span className={styles.badge}>
                 {ind.kind === 'standalone' ? 'S' : 'L'}
               </span>
             </div>
 
-            {isWatched && val !== undefined && (
-              typeof val === 'number' ? (
-                <div className={styles.scalarValue}>{formatValue(val, ind)}</div>
-              ) : (
+            {isWatched && isScalar && (
+              <div className={styles.scalarValue}>{formatValue(val as number, ind)}</div>
+            )}
+
+            {isWatched && isScalar && isExpanded && (
+              <div className={styles.sparklineWrap}>
+                <IndicatorSparkline
+                  data={history[ind.id] || []}
+                  generation={generation}
+                  height={60}
+                />
+              </div>
+            )}
+
+            {isWatched && isFreq && !isExpanded && (
+              <div className={styles.freqTable}>
+                {Object.entries(val as Record<string, number>).map(([k, count]) => (
+                  <div key={k} className={styles.freqRow}>
+                    <span className={styles.freqKey}>{k}</span>
+                    <span className={styles.freqCount}>{count}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {isWatched && isFreq && isExpanded && (() => {
+              const freqMap = val as Record<string, number>;
+              const entries = Object.entries(freqMap);
+              const maxCount = Math.max(...entries.map(([, c]) => c), 1);
+              return (
                 <div className={styles.freqTable}>
-                  {Object.entries(val).map(([k, count]) => (
-                    <div key={k} className={styles.freqRow}>
+                  {entries.map(([k, count]) => (
+                    <div key={k} className={styles.freqBarRow}>
                       <span className={styles.freqKey}>{k}</span>
+                      <div className={styles.freqBarTrack}>
+                        <div
+                          className={styles.freqBar}
+                          style={{ width: `${(count / maxCount) * 100}%` }}
+                        />
+                      </div>
                       <span className={styles.freqCount}>{count}</span>
                     </div>
                   ))}
                 </div>
-              )
-            )}
+              );
+            })()}
           </div>
         );
       })}

--- a/src/simulator/IndicatorSparkline.tsx
+++ b/src/simulator/IndicatorSparkline.tsx
@@ -1,0 +1,138 @@
+import { useRef, useEffect, useState } from 'react';
+
+interface SparklineProps {
+  data: number[];
+  generation: number;
+  height: number;
+}
+
+const LINE_COLOR = '#4cc9f0';
+const FILL_COLOR = 'rgba(76, 201, 240, 0.12)';
+const AXIS_COLOR = '#506070';
+const LABEL_COLOR = '#8090a0';
+const LABEL_FONT = '7.5px monospace';
+const LEFT_MARGIN = 24;
+const BOTTOM_MARGIN = 10;
+const RIGHT_PAD = 1;
+const TOP_PAD = 1;
+
+function formatAxisValue(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+  if (abs >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+  if (Number.isInteger(v)) return String(v);
+  return v.toFixed(1);
+}
+
+export function IndicatorSparkline({ data, generation, height }: SparklineProps) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [width, setWidth] = useState(0);
+
+  // Measure container width
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) setWidth(Math.floor(entry.contentRect.width));
+    });
+    ro.observe(el);
+    setWidth(Math.floor(el.clientWidth));
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || data.length < 2 || width < 40) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    const plotLeft = LEFT_MARGIN;
+    const plotRight = width - RIGHT_PAD;
+    const plotTop = TOP_PAD;
+    const plotBottom = height - BOTTOM_MARGIN;
+    const plotW = plotRight - plotLeft;
+    const plotH = plotBottom - plotTop;
+
+    // Y range
+    let yMin = Infinity, yMax = -Infinity;
+    for (let i = 0; i < data.length; i++) {
+      if (data[i]! < yMin) yMin = data[i]!;
+      if (data[i]! > yMax) yMax = data[i]!;
+    }
+    if (yMin === yMax) { yMin -= 1; yMax += 1; }
+    const yPad = (yMax - yMin) * 0.06;
+    yMin -= yPad;
+    yMax += yPad;
+    const yRange = yMax - yMin;
+
+    const n = data.length;
+    const xStep = plotW / (n - 1);
+    const toX = (i: number) => plotLeft + i * xStep;
+    const toY = (v: number) => plotTop + plotH - ((v - yMin) / yRange) * plotH;
+
+    // Y-axis labels
+    ctx.font = LABEL_FONT;
+    ctx.fillStyle = LABEL_COLOR;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillText(formatAxisValue(yMax), LEFT_MARGIN - 2, plotTop);
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(formatAxisValue(yMin), LEFT_MARGIN - 2, plotBottom);
+
+    // X-axis labels
+    const genStart = Math.max(0, generation - n + 1);
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(String(genStart), plotLeft, plotBottom + 1);
+    ctx.textAlign = 'right';
+    ctx.fillText(String(generation), plotRight, plotBottom + 1);
+
+    // Axis lines
+    ctx.strokeStyle = AXIS_COLOR;
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(plotLeft, plotTop);
+    ctx.lineTo(plotLeft, plotBottom);
+    ctx.lineTo(plotRight, plotBottom);
+    ctx.stroke();
+
+    // Fill
+    ctx.beginPath();
+    ctx.moveTo(toX(0), toY(data[0]!));
+    for (let i = 1; i < n; i++) ctx.lineTo(toX(i), toY(data[i]!));
+    ctx.lineTo(toX(n - 1), plotBottom);
+    ctx.lineTo(toX(0), plotBottom);
+    ctx.closePath();
+    ctx.fillStyle = FILL_COLOR;
+    ctx.fill();
+
+    // Line
+    ctx.beginPath();
+    ctx.moveTo(toX(0), toY(data[0]!));
+    for (let i = 1; i < n; i++) ctx.lineTo(toX(i), toY(data[i]!));
+    ctx.strokeStyle = LINE_COLOR;
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, data.length, data[data.length - 1], generation, width, height]);
+
+  if (data.length < 2) return null;
+
+  return (
+    <div ref={wrapRef} style={{ width: '100%' }}>
+      {width > 0 && (
+        <canvas
+          ref={canvasRef}
+          style={{ width, height, display: 'block' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/simulator/SimulatorView.module.css
+++ b/src/simulator/SimulatorView.module.css
@@ -18,37 +18,98 @@
   overflow-y: auto;
 }
 
-.rightColumn {
-  width: 200px;
-  min-width: 200px;
+/* --- Right side panel (shared, resizable via left border drag) --- */
+
+.rightPanel {
+  background: #16213e;
+  width: 220px;
+  min-width: 160px;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid #2d4059;
-  background: #16213e;
+  position: relative;
+  overflow: visible;
 }
 
-.rightSubPanel {
-  padding: 12px;
+.rightPanelCollapseTab {
+  position: absolute;
+  top: 8px;
+  left: -18px;
+  z-index: 6;
+  background: rgba(30, 42, 58, 0.9);
+  border: 1px solid #2d4059;
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+  color: #6080a0;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 12px 4px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.rightPanelCollapseTab:hover {
+  color: #4cc9f0;
+}
+
+.rightPanelResizeHandle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 5;
+  background: #2d4059;
+  transition: background 0.15s;
+}
+
+.rightPanelResizeHandle:hover,
+.rightPanelResizeHandle:active {
+  background: #4cc9f0;
+}
+
+.rightPanelSection {
+  padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   overflow-y: auto;
 }
 
-.rightSubPanel + .rightSubPanel {
+.rightPanelSection + .rightPanelSection {
   border-top: 1px solid #2d4059;
 }
 
-/* When indicators panel is also open, brush panel shrinks to content */
-.rightSubPanelShrink {
+/* Brush section: shrink to content */
+.rightSectionBrush {
   flex: 0 0 auto;
-  max-height: 35%;
 }
 
-/* Indicators panel grows to fill remaining space */
-.rightSubPanelGrow {
+/* Indicators section: fill remaining space */
+.rightSectionIndicators {
   flex: 1 1 0;
   min-height: 0;
+}
+
+.panelExpandBtnRight {
+  position: absolute;
+  top: 8px;
+  right: 0;
+  z-index: 10;
+  background: rgba(30, 42, 58, 0.9);
+  border: 1px solid #2d4059;
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+  color: #6080a0;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 12px 4px;
+  transition: color 0.15s;
+  line-height: 1;
+}
+
+.panelExpandBtnRight:hover {
+  color: #4cc9f0;
 }
 
 .panelHeader {
@@ -105,31 +166,6 @@
   color: #4cc9f0;
 }
 
-.rightExpandBtns {
-  position: absolute;
-  top: 8px;
-  right: 0;
-  z-index: 10;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.panelExpandBtnRight {
-  background: rgba(30, 42, 58, 0.9);
-  border: 1px solid #2d4059;
-  border-right: none;
-  border-radius: 4px 0 0 4px;
-  color: #6080a0;
-  font-size: 0.9rem;
-  cursor: pointer;
-  padding: 12px 4px;
-  transition: color 0.15s;
-}
-
-.panelExpandBtnRight:hover {
-  color: #4cc9f0;
-}
 
 /* --- Stat & control reusables --- */
 

--- a/src/simulator/SimulatorView.module.css
+++ b/src/simulator/SimulatorView.module.css
@@ -18,6 +18,39 @@
   overflow-y: auto;
 }
 
+.rightColumn {
+  width: 200px;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid #2d4059;
+  background: #16213e;
+}
+
+.rightSubPanel {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+}
+
+.rightSubPanel + .rightSubPanel {
+  border-top: 1px solid #2d4059;
+}
+
+/* When indicators panel is also open, brush panel shrinks to content */
+.rightSubPanelShrink {
+  flex: 0 0 auto;
+  max-height: 35%;
+}
+
+/* Indicators panel grows to fill remaining space */
+.rightSubPanelGrow {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
 .panelHeader {
   display: flex;
   align-items: center;
@@ -72,11 +105,17 @@
   color: #4cc9f0;
 }
 
-.panelExpandBtnRight {
+.rightExpandBtns {
   position: absolute;
   top: 8px;
   right: 0;
   z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.panelExpandBtnRight {
   background: rgba(30, 42, 58, 0.9);
   border: 1px solid #2d4059;
   border-right: none;

--- a/src/simulator/SimulatorView.module.css
+++ b/src/simulator/SimulatorView.module.css
@@ -446,6 +446,12 @@
   border-color: #4cc9f0;
 }
 
+.zoomBtnActive {
+  color: #4cc9f0;
+  border-color: #4cc9f0;
+  background: rgba(76, 201, 240, 0.12);
+}
+
 /* --- Input mapping tabs (in brush panel) --- */
 
 .mappingTabs {

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -46,6 +46,8 @@ export function SimulatorView() {
   // Indicator values stored in ref (not state) to avoid extra re-renders on every step.
   // The component already re-renders from setGeneration, so ref values are read during that render.
   const indicatorValuesRef = useRef<Record<string, number | Record<string, number>>>({});
+  const indicatorHistoryRef = useRef<Record<string, number[]>>({});
+  const chartExpandedRef = useRef<Set<string>>(new Set());
 
   // GIF recording state
   const [recording, setRecording] = useState(false);
@@ -230,7 +232,23 @@ export function SimulatorView() {
     const msg = e.data;
     if (msg.type === 'stepped') {
       colorsRef.current = msg.colors as Uint8ClampedArray;
-      if (msg.indicators) indicatorValuesRef.current = msg.indicators;
+      if (msg.indicators) {
+        indicatorValuesRef.current = msg.indicators;
+        // Collect history for indicators with expanded charts (scalar values only)
+        const expanded = chartExpandedRef.current;
+        if (expanded.size > 0) {
+          const hist = indicatorHistoryRef.current;
+          for (const id of expanded) {
+            const v = msg.indicators[id];
+            if (typeof v === 'number') {
+              let arr = hist[id];
+              if (!arr) { arr = []; hist[id] = arr; }
+              arr.push(v);
+              if (arr.length > 500) arr.shift();
+            }
+          }
+        }
+      }
       const gen = msg.generation as number;
       gpsGens.current += gen - lastGenForGps.current;
       lastGenForGps.current = gen;
@@ -379,6 +397,7 @@ export function SimulatorView() {
     setGeneration(0);
     setPlaying(false);
     indicatorValuesRef.current = {};
+    indicatorHistoryRef.current = {};
     pendingStep.current = false;
     lastGenForGps.current = 0;
     gpsGens.current = 0;
@@ -786,8 +805,8 @@ export function SimulatorView() {
   };
 
   const [leftPanelOpen, setLeftPanelOpen] = useState(true);
-  const [brushPanelOpen, setBrushPanelOpen] = useState(false);
-  const [indicatorsPanelOpen, setIndicatorsPanelOpen] = useState(true);
+  const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const rightPanelRef = useRef<HTMLDivElement>(null);
 
   const modelAttrs = model.attributes.filter(a => a.isModelAttribute);
   const attrToColorMappings = model.mappings.filter(m => m.isAttributeToColor);
@@ -977,77 +996,104 @@ export function SimulatorView() {
           >#</button>
         </div>
 
-        {/* Right-side expand buttons (stacked vertically) */}
-        <div className={styles.rightExpandBtns} data-sim-overlay>
-          {!brushPanelOpen && (
-            <button className={styles.panelExpandBtnRight} onClick={() => setBrushPanelOpen(true)} title="Open brush">&#9998;</button>
-          )}
-          {!indicatorsPanelOpen && (model.indicators || []).length > 0 && (
-            <button className={styles.panelExpandBtnRight} onClick={() => setIndicatorsPanelOpen(true)} title="Open indicators">&#x1D4D8;</button>
-          )}
-        </div>
+        {/* Right panel expand button */}
+        {!rightPanelOpen && (
+          <button className={styles.panelExpandBtnRight} data-sim-overlay
+            onClick={() => setRightPanelOpen(true)} title="Open side panel">&lsaquo;</button>
+        )}
       </div>
 
-      {/* === Right Column (two stacked panels with proper flex sizing) === */}
-      {(brushPanelOpen || (indicatorsPanelOpen && (model.indicators || []).length > 0)) && (
-        <div className={styles.rightColumn}>
-          {/* Brush Panel (top, shrink-to-fit when indicators open) */}
-          {brushPanelOpen && (
-            <div className={`${styles.rightSubPanel} ${indicatorsPanelOpen && (model.indicators || []).length > 0 ? styles.rightSubPanelShrink : ''}`}>
-              <div className={styles.panelHeader}>
-                <span className={styles.panelTitle}>Input Mapping (C{'\u2192'}A)</span>
-                <button className={styles.panelCollapseBtn} onClick={() => setBrushPanelOpen(false)}>&rsaquo;</button>
-              </div>
-              {colorToAttrMappings.length > 0 && (
-                <div className={styles.mappingTabs}>
-                  {colorToAttrMappings.map(m => (
-                    <button
-                      key={m.id}
-                      className={`${styles.mappingTab} ${brushMapping === m.id ? styles.mappingTabActive : ''}`}
-                      onClick={() => setBrushMapping(m.id)}
-                    >
-                      {m.name}
-                    </button>
-                  ))}
-                </div>
-              )}
-              <div className={styles.fieldRow}>
-                <span className={styles.statLabel}>Color</span>
-                <input type="color" className={styles.colorPicker} value={brushColor}
-                  onChange={e => setBrushColor(e.target.value)} />
-              </div>
-              <div className={styles.fieldRow}>
-                <span className={styles.statLabel}>W</span>
-                <input className={styles.brushInput} type="number" min={1} max={(gridWidth.current || simWidth) * 2} value={brushW}
-                  onChange={e => setBrushW(Math.max(1, Number(e.target.value) || 1))} />
-                <span className={styles.statLabel}>H</span>
-                <input className={styles.brushInput} type="number" min={1} max={(gridHeight.current || simHeight) * 2} value={brushH}
-                  onChange={e => setBrushH(Math.max(1, Number(e.target.value) || 1))} />
-              </div>
-              <hr className={styles.divider} />
-              <button className={styles.controlButton} onClick={() => imageInputRef.current?.click()}>
-                Open Image
-              </button>
-              <input ref={imageInputRef} type="file" accept=".png,.bmp,.jpg,.jpeg" style={{ display: 'none' }} onChange={handleImageImport} />
-              <label className={styles.checkRow}>
-                <input type="checkbox" checked={showBrushCursor} onChange={e => setShowBrushCursor(e.target.checked)} />
-                Show brush cursor
-              </label>
-              <div className={styles.hint}>LMB: paint / RMB: pan / Ctrl+LMB drag: resize brush</div>
-            </div>
-          )}
+      {/* === Right Panel (single shared panel, resizable via left border drag) === */}
+      {rightPanelOpen && (
+        <div className={styles.rightPanel} ref={rightPanelRef}>
+          {/* Collapse button outside panel (left edge tab) */}
+          <button
+            className={styles.rightPanelCollapseTab}
+            onClick={() => setRightPanelOpen(false)}
+            title="Close side panel"
+          >&rsaquo;</button>
 
-          {/* Indicators Panel (bottom, grows to fill remaining space) */}
-          {indicatorsPanelOpen && (model.indicators || []).length > 0 && (
-            <div className={`${styles.rightSubPanel} ${styles.rightSubPanelGrow}`}>
+          {/* Drag handle on full left border */}
+          <div
+            className={styles.rightPanelResizeHandle}
+            onMouseDown={e => {
+              e.preventDefault();
+              const panel = rightPanelRef.current;
+              if (!panel) return;
+              const startX = e.clientX;
+              const startW = panel.offsetWidth;
+              const onMove = (ev: MouseEvent) => {
+                const newW = Math.max(160, startW - (ev.clientX - startX));
+                panel.style.width = newW + 'px';
+              };
+              const onUp = () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+              };
+              document.addEventListener('mousemove', onMove);
+              document.addEventListener('mouseup', onUp);
+            }}
+          />
+
+          {/* Brush Section (top, shrinks to content) */}
+          <div className={`${styles.rightPanelSection} ${styles.rightSectionBrush}`}>
+            <div className={styles.panelHeader}>
+              <span className={styles.panelTitle}>Input Mapping (C{'\u2192'}A)</span>
+            </div>
+            {colorToAttrMappings.length > 0 && (
+              <div className={styles.mappingTabs}>
+                {colorToAttrMappings.map(m => (
+                  <button
+                    key={m.id}
+                    className={`${styles.mappingTab} ${brushMapping === m.id ? styles.mappingTabActive : ''}`}
+                    onClick={() => setBrushMapping(m.id)}
+                  >
+                    {m.name}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className={styles.fieldRow}>
+              <span className={styles.statLabel}>Color</span>
+              <input type="color" className={styles.colorPicker} value={brushColor}
+                onChange={e => setBrushColor(e.target.value)} />
+            </div>
+            <div className={styles.fieldRow}>
+              <span className={styles.statLabel}>W</span>
+              <input className={styles.brushInput} type="number" min={1} max={(gridWidth.current || simWidth) * 2} value={brushW}
+                onChange={e => setBrushW(Math.max(1, Number(e.target.value) || 1))} />
+              <span className={styles.statLabel}>H</span>
+              <input className={styles.brushInput} type="number" min={1} max={(gridHeight.current || simHeight) * 2} value={brushH}
+                onChange={e => setBrushH(Math.max(1, Number(e.target.value) || 1))} />
+            </div>
+            <hr className={styles.divider} />
+            <button className={styles.controlButton} onClick={() => imageInputRef.current?.click()}>
+              Open Image
+            </button>
+            <input ref={imageInputRef} type="file" accept=".png,.bmp,.jpg,.jpeg" style={{ display: 'none' }} onChange={handleImageImport} />
+            <label className={styles.checkRow}>
+              <input type="checkbox" checked={showBrushCursor} onChange={e => setShowBrushCursor(e.target.checked)} />
+              Show brush cursor
+            </label>
+            <div className={styles.hint}>LMB: paint / RMB: pan / Ctrl+LMB drag: resize brush</div>
+          </div>
+
+          {/* Indicators Section (bottom, fills remaining space) */}
+          {(model.indicators || []).length > 0 && (
+            <div className={`${styles.rightPanelSection} ${styles.rightSectionIndicators}`}>
               <div className={styles.panelHeader}>
                 <span className={styles.panelTitle}>Indicators</span>
-                <button className={styles.panelCollapseBtn} onClick={() => setIndicatorsPanelOpen(false)}>&rsaquo;</button>
               </div>
               <IndicatorDisplay
                 indicators={model.indicators || []}
                 values={indicatorValuesRef.current}
+                history={indicatorHistoryRef.current}
+                generation={generation}
                 onToggleWatch={(id, watched) => updateIndicator(id, { watched })}
+                onChartToggle={(id, expanded) => {
+                  if (expanded) chartExpandedRef.current.add(id);
+                  else chartExpandedRef.current.delete(id);
+                }}
               />
             </div>
           )}

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useModel } from '../model/ModelContext';
 import { compileGraph } from '../modeler/vpl/compiler/compile';
 import { GIFEncoder, quantize, applyPalette } from 'gifenc';
+import { IndicatorDisplay } from './IndicatorDisplay';
 import styles from './SimulatorView.module.css';
 
 const SIM_SETTINGS_KEY = 'genesisca_sim_settings';
@@ -16,7 +17,7 @@ function loadSimSettings(): Record<string, unknown> {
 
 export function SimulatorView() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { model } = useModel();
+  const { model, updateIndicator } = useModel();
   const workerRef = useRef<Worker | null>(null);
   const pendingStep = useRef(false);
 
@@ -40,6 +41,11 @@ export function SimulatorView() {
   const [brushMapping, setBrushMapping] = useState((saved.current.brushMapping as string) ?? '');
   const [showBrushCursor, setShowBrushCursor] = useState((saved.current.showBrushCursor as boolean) ?? true);
   const [showGridlines, setShowGridlines] = useState((saved.current.showGridlines as boolean) ?? false);
+
+  // Indicator values from worker
+  // Indicator values stored in ref (not state) to avoid extra re-renders on every step.
+  // The component already re-renders from setGeneration, so ref values are read during that render.
+  const indicatorValuesRef = useRef<Record<string, number | Record<string, number>>>({});
 
   // GIF recording state
   const [recording, setRecording] = useState(false);
@@ -94,13 +100,14 @@ export function SimulatorView() {
   // 1:1 pixel source canvas (reused across draws)
   const srcCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  // Compile graph
+  // Compile graph (deps include indicator watched state since it affects compiled code)
   const compileModel = useCallback(() => {
     const result = compileGraph(model.graphNodes, model.graphEdges, model);
     setCompiledCode(result.stepCode);
     setCompileError(result.error ?? '');
     return result;
-  }, [model.graphNodes, model.graphEdges]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model.graphNodes, model.graphEdges, model.indicators]);
 
   // Draw using ImageData + zoom/pan transform
   const draw = useCallback(() => {
@@ -223,6 +230,7 @@ export function SimulatorView() {
     const msg = e.data;
     if (msg.type === 'stepped') {
       colorsRef.current = msg.colors as Uint8ClampedArray;
+      if (msg.indicators) indicatorValuesRef.current = msg.indicators;
       const gen = msg.generation as number;
       gpsGens.current += gen - lastGenForGps.current;
       lastGenForGps.current = gen;
@@ -358,22 +366,69 @@ export function SimulatorView() {
       inputColorCodes: result.inputColorCodes,
       outputMappingCodes: result.outputMappingCodes,
       activeViewer: viewer,
+      indicators: (model.indicators || []).map(i => ({
+        id: i.id, kind: i.kind, dataType: i.dataType,
+        defaultValue: i.defaultValue, accumulationMode: i.accumulationMode,
+        tagOptions: i.tagOptions,
+        linkedAttributeId: i.linkedAttributeId,
+        linkedAggregation: i.linkedAggregation,
+        binCount: i.binCount, watched: i.watched,
+      })),
     });
     workerRef.current = worker;
     setGeneration(0);
     setPlaying(false);
+    indicatorValuesRef.current = {};
     pendingStep.current = false;
     lastGenForGps.current = 0;
     gpsGens.current = 0;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, compileModel]);
 
-  // Full worker init on mount (tab switch) and whenever model changes while on Simulator tab.
-  // SimulatorView is conditionally rendered — unmounted when on other tabs — so this only
-  // fires when the user is actually looking at the simulator.
+  // Terminate worker on unmount only (not on re-renders)
   useEffect(() => {
-    initWorkerWithDimensions(model.properties.gridWidth, model.properties.gridHeight);
-    return () => workerRef.current?.terminate();
+    return () => {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // Smart init vs recompile: compare previous model to decide.
+  // Full reinit for structural changes (grid size, attributes, neighborhoods, mappings, update mode).
+  // Soft recompile for graph or indicator watch changes (preserves grid state).
+  const prevModelRef = useRef<typeof model | null>(null);
+  useEffect(() => {
+    const prev = prevModelRef.current;
+    prevModelRef.current = model;
+
+    const needsFullInit = !prev || !workerRef.current
+      || prev.properties.gridWidth !== model.properties.gridWidth
+      || prev.properties.gridHeight !== model.properties.gridHeight
+      || prev.properties.boundaryTreatment !== model.properties.boundaryTreatment
+      || prev.properties.updateMode !== model.properties.updateMode
+      || prev.properties.asyncScheme !== model.properties.asyncScheme
+      || prev.attributes !== model.attributes
+      || prev.neighborhoods !== model.neighborhoods
+      || prev.mappings !== model.mappings;
+
+    if (needsFullInit) {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+      initWorkerWithDimensions(model.properties.gridWidth, model.properties.gridHeight);
+    } else {
+      // Graph or indicator watch change only → soft recompile (preserves grid)
+      const result = compileGraph(model.graphNodes, model.graphEdges, model);
+      setCompiledCode(result.stepCode);
+      setCompileError(result.error ?? '');
+      workerRef.current?.postMessage({
+        type: 'recompile',
+        stepCode: result.stepCode,
+        inputColorCodes: result.inputColorCodes,
+        outputMappingCodes: result.outputMappingCodes || [],
+        updateMode: model.properties.updateMode,
+        asyncScheme: model.properties.asyncScheme,
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, compileModel]);
 
@@ -731,7 +786,8 @@ export function SimulatorView() {
   };
 
   const [leftPanelOpen, setLeftPanelOpen] = useState(true);
-  const [rightPanelOpen, setRightPanelOpen] = useState(false);
+  const [brushPanelOpen, setBrushPanelOpen] = useState(false);
+  const [indicatorsPanelOpen, setIndicatorsPanelOpen] = useState(true);
 
   const modelAttrs = model.attributes.filter(a => a.isModelAttribute);
   const attrToColorMappings = model.mappings.filter(m => m.isAttributeToColor);
@@ -921,55 +977,80 @@ export function SimulatorView() {
           >#</button>
         </div>
 
-        {!rightPanelOpen && (
-          <button className={styles.panelExpandBtnRight} data-sim-overlay
-            onClick={() => setRightPanelOpen(true)} title="Open brush">&#9998;</button>
-        )}
+        {/* Right-side expand buttons (stacked vertically) */}
+        <div className={styles.rightExpandBtns} data-sim-overlay>
+          {!brushPanelOpen && (
+            <button className={styles.panelExpandBtnRight} onClick={() => setBrushPanelOpen(true)} title="Open brush">&#9998;</button>
+          )}
+          {!indicatorsPanelOpen && (model.indicators || []).length > 0 && (
+            <button className={styles.panelExpandBtnRight} onClick={() => setIndicatorsPanelOpen(true)} title="Open indicators">&#x1D4D8;</button>
+          )}
+        </div>
       </div>
 
-      {/* === Right Panel (collapsible — Brush) === */}
-      {rightPanelOpen && (
-        <div className={styles.sidePanel}>
-          <div className={styles.panelHeader}>
-            <span className={styles.panelTitle}>Input Mapping (C{'\u2192'}A)</span>
-            <button className={styles.panelCollapseBtn} onClick={() => setRightPanelOpen(false)}>&rsaquo;</button>
-          </div>
-          {colorToAttrMappings.length > 0 && (
-            <div className={styles.mappingTabs}>
-              {colorToAttrMappings.map(m => (
-                <button
-                  key={m.id}
-                  className={`${styles.mappingTab} ${brushMapping === m.id ? styles.mappingTabActive : ''}`}
-                  onClick={() => setBrushMapping(m.id)}
-                >
-                  {m.name}
-                </button>
-              ))}
+      {/* === Right Column (two stacked panels with proper flex sizing) === */}
+      {(brushPanelOpen || (indicatorsPanelOpen && (model.indicators || []).length > 0)) && (
+        <div className={styles.rightColumn}>
+          {/* Brush Panel (top, shrink-to-fit when indicators open) */}
+          {brushPanelOpen && (
+            <div className={`${styles.rightSubPanel} ${indicatorsPanelOpen && (model.indicators || []).length > 0 ? styles.rightSubPanelShrink : ''}`}>
+              <div className={styles.panelHeader}>
+                <span className={styles.panelTitle}>Input Mapping (C{'\u2192'}A)</span>
+                <button className={styles.panelCollapseBtn} onClick={() => setBrushPanelOpen(false)}>&rsaquo;</button>
+              </div>
+              {colorToAttrMappings.length > 0 && (
+                <div className={styles.mappingTabs}>
+                  {colorToAttrMappings.map(m => (
+                    <button
+                      key={m.id}
+                      className={`${styles.mappingTab} ${brushMapping === m.id ? styles.mappingTabActive : ''}`}
+                      onClick={() => setBrushMapping(m.id)}
+                    >
+                      {m.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div className={styles.fieldRow}>
+                <span className={styles.statLabel}>Color</span>
+                <input type="color" className={styles.colorPicker} value={brushColor}
+                  onChange={e => setBrushColor(e.target.value)} />
+              </div>
+              <div className={styles.fieldRow}>
+                <span className={styles.statLabel}>W</span>
+                <input className={styles.brushInput} type="number" min={1} max={(gridWidth.current || simWidth) * 2} value={brushW}
+                  onChange={e => setBrushW(Math.max(1, Number(e.target.value) || 1))} />
+                <span className={styles.statLabel}>H</span>
+                <input className={styles.brushInput} type="number" min={1} max={(gridHeight.current || simHeight) * 2} value={brushH}
+                  onChange={e => setBrushH(Math.max(1, Number(e.target.value) || 1))} />
+              </div>
+              <hr className={styles.divider} />
+              <button className={styles.controlButton} onClick={() => imageInputRef.current?.click()}>
+                Open Image
+              </button>
+              <input ref={imageInputRef} type="file" accept=".png,.bmp,.jpg,.jpeg" style={{ display: 'none' }} onChange={handleImageImport} />
+              <label className={styles.checkRow}>
+                <input type="checkbox" checked={showBrushCursor} onChange={e => setShowBrushCursor(e.target.checked)} />
+                Show brush cursor
+              </label>
+              <div className={styles.hint}>LMB: paint / RMB: pan / Ctrl+LMB drag: resize brush</div>
             </div>
           )}
-          <div className={styles.fieldRow}>
-            <span className={styles.statLabel}>Color</span>
-            <input type="color" className={styles.colorPicker} value={brushColor}
-              onChange={e => setBrushColor(e.target.value)} />
-          </div>
-          <div className={styles.fieldRow}>
-            <span className={styles.statLabel}>W</span>
-            <input className={styles.brushInput} type="number" min={1} max={(gridWidth.current || simWidth) * 2} value={brushW}
-              onChange={e => setBrushW(Math.max(1, Number(e.target.value) || 1))} />
-            <span className={styles.statLabel}>H</span>
-            <input className={styles.brushInput} type="number" min={1} max={(gridHeight.current || simHeight) * 2} value={brushH}
-              onChange={e => setBrushH(Math.max(1, Number(e.target.value) || 1))} />
-          </div>
-          <hr className={styles.divider} />
-          <button className={styles.controlButton} onClick={() => imageInputRef.current?.click()}>
-            Open Image
-          </button>
-          <input ref={imageInputRef} type="file" accept=".png,.bmp,.jpg,.jpeg" style={{ display: 'none' }} onChange={handleImageImport} />
-          <label className={styles.checkRow}>
-            <input type="checkbox" checked={showBrushCursor} onChange={e => setShowBrushCursor(e.target.checked)} />
-            Show brush cursor
-          </label>
-          <div className={styles.hint}>LMB: paint / RMB: pan / Ctrl+LMB drag: resize brush</div>
+
+          {/* Indicators Panel (bottom, grows to fill remaining space) */}
+          {indicatorsPanelOpen && (model.indicators || []).length > 0 && (
+            <div className={`${styles.rightSubPanel} ${styles.rightSubPanelGrow}`}>
+              <div className={styles.panelHeader}>
+                <span className={styles.panelTitle}>Indicators</span>
+                <button className={styles.panelCollapseBtn} onClick={() => setIndicatorsPanelOpen(false)}>&rsaquo;</button>
+              </div>
+              <IndicatorDisplay
+                indicators={model.indicators || []}
+                values={indicatorValuesRef.current}
+                onToggleWatch={(id, watched) => updateIndicator(id, { watched })}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -506,8 +506,8 @@ export function SimulatorView() {
       if (isResizingBrush.active) {
         const dx = e.clientX - isResizingBrush.startX;
         const dy = e.clientY - isResizingBrush.startY;
-        const maxW = gridWidth.current || simWidth;
-        const maxH = gridHeight.current || simHeight;
+        const maxW = (gridWidth.current || simWidth) * 2;
+        const maxH = (gridHeight.current || simHeight) * 2;
         const newW = Math.max(1, Math.min(maxW, isResizingBrush.startW + Math.round(dx / 5)));
         const newH = Math.max(1, Math.min(maxH, isResizingBrush.startH - Math.round(dy / 5)));
         setBrushW(newW);
@@ -954,10 +954,10 @@ export function SimulatorView() {
           </div>
           <div className={styles.fieldRow}>
             <span className={styles.statLabel}>W</span>
-            <input className={styles.brushInput} type="number" min={1} max={gridWidth.current || simWidth} value={brushW}
+            <input className={styles.brushInput} type="number" min={1} max={(gridWidth.current || simWidth) * 2} value={brushW}
               onChange={e => setBrushW(Math.max(1, Number(e.target.value) || 1))} />
             <span className={styles.statLabel}>H</span>
-            <input className={styles.brushInput} type="number" min={1} max={gridHeight.current || simHeight} value={brushH}
+            <input className={styles.brushInput} type="number" min={1} max={(gridHeight.current || simHeight) * 2} value={brushH}
               onChange={e => setBrushH(Math.max(1, Number(e.target.value) || 1))} />
           </div>
           <hr className={styles.divider} />

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -39,6 +39,7 @@ export function SimulatorView() {
   const [brushH, setBrushH] = useState((saved.current.brushH as number) ?? 1);
   const [brushMapping, setBrushMapping] = useState((saved.current.brushMapping as string) ?? '');
   const [showBrushCursor, setShowBrushCursor] = useState((saved.current.showBrushCursor as boolean) ?? true);
+  const [showGridlines, setShowGridlines] = useState((saved.current.showGridlines as boolean) ?? false);
 
   // GIF recording state
   const [recording, setRecording] = useState(false);
@@ -53,12 +54,12 @@ export function SimulatorView() {
       try {
         localStorage.setItem(SIM_SETTINGS_KEY, JSON.stringify({
           targetFps, unlimitedFps, gensPerFrame, unlimitedGens,
-          activeViewer, brushColor, brushW, brushH, brushMapping, showBrushCursor,
+          activeViewer, brushColor, brushW, brushH, brushMapping, showBrushCursor, showGridlines,
         }));
       } catch { /* localStorage full */ }
     }, 300);
     return () => clearTimeout(timer);
-  }, [targetFps, unlimitedFps, gensPerFrame, unlimitedGens, activeViewer, brushColor, brushW, brushH, brushMapping, showBrushCursor]);
+  }, [targetFps, unlimitedFps, gensPerFrame, unlimitedGens, activeViewer, brushColor, brushW, brushH, brushMapping, showBrushCursor, showGridlines]);
 
   // F3: Runtime model attribute values
   const [runtimeModelAttrs, setRuntimeModelAttrs] = useState<Record<string, number>>({});
@@ -149,6 +150,28 @@ export function SimulatorView() {
     const oy = (parentH - scaledH) / 2 + pan.y;
 
     ctx.drawImage(srcCanvasRef.current, ox, oy, scaledW, scaledH);
+
+    // Draw gridlines when zoomed in enough (cells >= 4px)
+    if (showGridlinesRef.current && scale >= 4) {
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      for (let col = 0; col <= w; col++) {
+        const x = ox + col * scale;
+        if (x >= 0 && x <= parentW) {
+          ctx.moveTo(x, Math.max(0, oy));
+          ctx.lineTo(x, Math.min(parentH, oy + scaledH));
+        }
+      }
+      for (let row = 0; row <= h; row++) {
+        const y = oy + row * scale;
+        if (y >= 0 && y <= parentH) {
+          ctx.moveTo(Math.max(0, ox), y);
+          ctx.lineTo(Math.min(parentW, ox + scaledW), y);
+        }
+      }
+      ctx.stroke();
+    }
 
     // Draw brush cursor rectangle
     const cursor = cursorGrid.current;
@@ -372,6 +395,8 @@ export function SimulatorView() {
   useEffect(() => { activeViewerRef.current = activeViewer; }, [activeViewer]);
   const showBrushCursorRef = useRef(true);
   useEffect(() => { showBrushCursorRef.current = showBrushCursor; }, [showBrushCursor]);
+  const showGridlinesRef = useRef(false);
+  useEffect(() => { showGridlinesRef.current = showGridlines; }, [showGridlines]);
   useEffect(() => { brushMappingRef.current = brushMapping; }, [brushMapping]);
 
   /** Convert screen coords to grid cell coords */
@@ -889,6 +914,11 @@ export function SimulatorView() {
           <button className={styles.zoomBtn} onClick={() => { zoomRef.current = Math.min(50, zoomRef.current * 1.3); draw(); }} title="Zoom in">+</button>
           <button className={styles.zoomBtn} onClick={() => { zoomRef.current = Math.max(0.1, zoomRef.current / 1.3); draw(); }} title="Zoom out">&minus;</button>
           <button className={styles.zoomBtn} onClick={handleResetView} title="Fit view">&#x2922;</button>
+          <button
+            className={`${styles.zoomBtn} ${showGridlines ? styles.zoomBtnActive : ''}`}
+            onClick={() => { setShowGridlines(v => !v); draw(); }}
+            title="Toggle gridlines"
+          >#</button>
         </div>
 
         {!rightPanelOpen && (

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -30,6 +30,7 @@ interface InitMsg {
   inputColorCodes: Array<{ mappingId: string; code: string }>;
   outputMappingCodes: Array<{ mappingId: string; code: string }>;
   activeViewer: string;
+  indicators?: IndicatorDef[];
 }
 
 interface StepMsg { type: 'step'; count: number; activeViewer: string; skipColorPass?: boolean }
@@ -45,7 +46,21 @@ interface RecompileMsg { type: 'recompile'; stepCode: string; inputColorCodes: A
 interface UpdateModelAttrsMsg { type: 'updateModelAttrs'; attrs: Record<string, number> }
 interface ImportImageMsg { type: 'importImage'; pixels: Uint8ClampedArray; mappingId: string; activeViewer: string }
 
-type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg;
+interface IndicatorDef {
+  id: string;
+  kind: string;
+  dataType: string;
+  defaultValue: string;
+  accumulationMode: string;
+  tagOptions?: string[];
+  linkedAttributeId?: string;
+  linkedAggregation?: string;
+  binCount?: number;
+  watched: boolean;
+}
+
+interface UpdateIndicatorsMsg { type: 'updateIndicators'; indicators: IndicatorDef[]; attributes: AttrDef[] }
+type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg | UpdateIndicatorsMsg;
 
 // ---------------------------------------------------------------------------
 // State
@@ -78,6 +93,16 @@ let outputMappingFns: Array<{ mappingId: string; fn: Function }> = [];
 
 // Cached model attributes
 let cachedModelAttrs: Record<string, unknown> = {};
+
+// Indicators
+let cachedIndicators: Record<string, number> = {};
+let standaloneDefaults: Record<string, number> = {};
+let standalonePerGenIds: string[] = [];
+let linkedDefs: Array<{
+  id: string; accumulationMode: string;
+}> = [];
+let linkedAccumulators: Record<string, number | Record<string, number>> = {};
+let linkedResults: Record<string, number | Record<string, number>> = {};
 
 // ---------------------------------------------------------------------------
 // Typed array creation by attribute type
@@ -228,7 +253,7 @@ function buildLoopArgs(): unknown[] {
     args.push(nbrIndices[nbr.id]);
     args.push(nbr.coords.length);
   }
-  args.push(cachedModelAttrs, colors, activeViewer);
+  args.push(cachedModelAttrs, colors, activeViewer, cachedIndicators, linkedResults);
   if (updateMode === 'asynchronous' && orderArray) args.push(orderArray);
   return args;
 }
@@ -242,12 +267,20 @@ function buildCellArgs(idx: number): unknown[] {
     args.push(nbrIndices[nbr.id]);
     args.push(nbr.coords.length);
   }
-  args.push(cachedModelAttrs, colors, activeViewer);
+  args.push(cachedModelAttrs, colors, activeViewer, cachedIndicators, linkedResults);
   return args;
 }
 
 function runStep(): void {
   const fn = stepFn!;
+
+  // Reset per-generation standalone indicators to defaults
+  if (standalonePerGenIds.length > 0) {
+    for (const id of standalonePerGenIds) cachedIndicators[id] = standaloneDefaults[id] ?? 0;
+  }
+
+  // Clear linked results (compiled step function will populate them)
+  if (linkedDefs.length > 0) linkedResults = {};
 
   // Async mode: shuffle/populate order array before each step
   if (updateMode === 'asynchronous' && orderArray) {
@@ -268,6 +301,26 @@ function runStep(): void {
 
   // ONE call per step — the loop is inside the compiled function
   fn(...buildLoopArgs());
+
+  // Handle linked indicator accumulation (skip when no linked indicators)
+  for (let _li = 0; _li < linkedDefs.length; _li++) {
+    const def = linkedDefs[_li]!;
+    if (!(def.id in linkedResults)) continue;
+    if (def.accumulationMode === 'accumulated') {
+      const cur = linkedResults[def.id]!;
+      if (typeof cur === 'number') {
+        linkedAccumulators[def.id] = ((linkedAccumulators[def.id] as number) || 0) + cur;
+        linkedResults[def.id] = linkedAccumulators[def.id] as number;
+      } else {
+        const prev = (linkedAccumulators[def.id] as Record<string, number>) || {};
+        for (const [k, v] of Object.entries(cur)) {
+          prev[k] = (prev[k] || 0) + v;
+        }
+        linkedAccumulators[def.id] = prev;
+        linkedResults[def.id] = { ...prev };
+      }
+    }
+  }
 
   // Swap buffers (sync mode only — async uses single buffer)
   if (updateMode !== 'asynchronous') {
@@ -310,6 +363,7 @@ function randomizeGrid(): void {
     const wArr = writeAttrs[attr.id]!;
     (wArr as Uint8Array).set(arr as Uint8Array);
   }
+  resetIndicators();
   generation = 0;
   // Prefer Output Mapping color pass (no generation advance) over runStep fallback
   const hasColorPassR = outputMappingFns.some(f => f.mappingId === activeViewer);
@@ -323,6 +377,7 @@ function resetGrid(): void {
     const wArr = writeAttrs[attr.id]!;
     for (let i = 0; i < total; i++) { arr[i] = dv; wArr[i] = dv; }
   }
+  resetIndicators();
   generation = 0;
   const hasColorPassRs = outputMappingFns.some(f => f.mappingId === activeViewer);
   if (hasColorPassRs) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
@@ -359,10 +414,57 @@ function runColorPass(): void {
   if (omFn) omFn.fn(...buildLoopArgs());
 }
 
+function initIndicators(defs: IndicatorDef[]): void {
+  cachedIndicators = {};
+  standaloneDefaults = {};
+  standalonePerGenIds = [];
+  linkedDefs = [];
+  linkedAccumulators = {};
+
+  for (const ind of defs) {
+    if (ind.kind === 'standalone') {
+      const dv = ind.dataType === 'bool'
+        ? (ind.defaultValue === 'true' ? 1 : 0)
+        : (parseFloat(ind.defaultValue) || 0);
+      cachedIndicators[ind.id] = dv;
+      standaloneDefaults[ind.id] = dv;
+      if (ind.accumulationMode === 'per-generation') {
+        standalonePerGenIds.push(ind.id);
+      }
+    } else if (ind.kind === 'linked') {
+      linkedDefs.push({
+        id: ind.id,
+        accumulationMode: ind.accumulationMode,
+      });
+    }
+  }
+}
+
+function resetIndicators(): void {
+  for (const id of Object.keys(cachedIndicators)) {
+    cachedIndicators[id] = standaloneDefaults[id] ?? 0;
+  }
+  linkedAccumulators = {};
+  linkedResults = {};
+}
+
 function sendColors(): void {
   const copy = new Uint8ClampedArray(colors);
+  // Only build indicators payload when there are entries (avoids overhead when no indicators)
+  const hasStandalone = standalonePerGenIds.length > 0 || Object.keys(standaloneDefaults).length > 0;
+  const hasLinked = linkedDefs.length > 0;
+  let indicators: Record<string, number | Record<string, number>> | undefined;
+  if (hasStandalone || hasLinked) {
+    indicators = {};
+    for (const id of Object.keys(cachedIndicators)) {
+      indicators[id] = cachedIndicators[id]!;
+    }
+    for (const id of Object.keys(linkedResults)) {
+      indicators[id] = linkedResults[id]!;
+    }
+  }
   self.postMessage(
-    { type: 'stepped', generation, colors: copy },
+    { type: 'stepped', generation, colors: copy, indicators },
     { transfer: [copy.buffer] },
   );
 }
@@ -399,6 +501,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
       }
 
       activeViewer = msg.activeViewer;
+      initIndicators(msg.indicators || []);
       initGrid();
       buildNeighborIndices();
       compileFns(msg.stepCode, msg.inputColorCodes, msg.outputMappingCodes || []);
@@ -489,6 +592,12 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
       }
       break;
     }
+
+    case 'updateIndicators': {
+      initIndicators(msg.indicators);
+      break;
+    }
+
 
     case 'importImage': {
       activeViewer = msg.activeViewer;


### PR DESCRIPTION
Here's the PR description:

---

## Summary

- **Indicators feature** — new quantitative monitoring system for tracking CA evolution beyond visual feedback. Standalone indicators (typed scalars writable via Get/Set/Update graph nodes) and Linked indicators (auto-aggregated from cell attributes: frequency counts, totals). Defined in Properties panel, displayed in a dedicated Simulator panel with eye-toggle for linked indicators to enable/disable computation.
- **Indicator charts** — Canvas2D sparkline time-series for scalar indicators (auto-scaling axes, generation labels, 500-point circular buffer) and horizontal histogram bars for frequency indicators. Charts toggled per-indicator, expanded by default. Right panel resizable via left-border drag handle.
- **Aggregation node enhancements** — new `indexes` output port on Group Assert, Count Matching, and new Get Neighbors Attr By Indexes node. Group Reduce gains `index` output for max/min/random. Compiler extended with multi-output scratch arrays.
- **Performance** — aggregation nodes use fast path (.every()/.some() or simple counter) when indexes output is unwired; direct indexed writes replace .push() when it is. Linked indicator aggregation runs as post-loop pass for correctness in async mode. Indicator values stored in ref (not React state) to avoid extra re-renders.
- **Macro scoping fix** — multi-output variable names inside macros now correctly scoped (regex boundary fix for underscore-suffixed names).
- **UX improvements** — compact Step node with singleton enforcement, duplicate edge prevention, Logic NOT port filtering, group resize fix, simulator gridlines toggle, brush size up to 2x grid dimensions.

## Test plan

- [ ] Create standalone indicator (integer) → add Get/Set/Update Indicator nodes → verify value updates during simulation
- [ ] Create linked bool frequency indicator → run → verify histogram bars show correct true/false proportions
- [ ] Toggle indicator eye off → verify values stop updating and performance improves; toggle back on → values resume (grid preserved, no reset)
- [ ] Expand sparkline chart → run simulation → verify line graph updates in real-time with axis labels
- [ ] Collapse chart → verify history stops collecting; re-expand → history resumes from where it left off
- [ ] Reset simulation → verify sparkline history clears
- [ ] Resize right panel via left border drag → verify sparkline and bars adapt to new width
- [ ] Async mode particle model → verify linked indicator counts are stable (no oscillation from mid-loop aggregation)
- [ ] Game of Life with Count Matching (no indexes wired) → verify performance matches pre-indicator baseline
- [ ] Wire Count Matching indexes → Get Neighbors Attr By Indexes → verify correct values with direct-write optimization
- [ ] Save/load .gcaproj with indicators → verify persistence and migration guard for old files
- [ ] Load Particles Random Walk from library → verify model and indicators work

