### PR TITLE
WebGPU stability sweep + Modeler/Simulator UX polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ A complete GenesisCA model definition consists of:
 - **Neighborhoods Panel** — interactive grid editor with per-neighborhood margin, optional per-cell tags for named access, and a Duplicate button for quick variations
 - **Mappings Panel** — Attribute-to-Color and Color-to-Attribute mapping definitions
 - **Indicators** — standalone (typed scalar, graph-writable) or linked (auto-aggregated from cell attributes: frequency, total), with per-generation or accumulated modes. Frequency indicators can be viewed as horizontal bars, multi-line time series, or stacked-area time series (viz button cycles the three; preference persists per indicator). End Conditions accept per-category comparisons on frequency indicators (e.g. pause when count of `alive` cells &ge; 100).
-- **Graph Editor** — 37 node types across 8 categories (event, flow, data, logic, aggregation, output, color, indicators), with RMB pan, scroll zoom, and snap-to-grid. Includes Switch (flow routing by conditions or value), Proportion Map, Interpolation, Color Interpolation, Aggregate (multi-input math), neighborhood tag-based access nodes, and a **Stop Event** node that pauses the simulator with a user-defined message when its flow input fires.
+- **Graph Editor** — 37 node types across 8 categories (event, flow, data, logic, aggregation, output, color, indicators), with RMB pan, scroll zoom, and snap-to-grid. Includes Switch (flow routing by conditions or value), Proportion Map and Color Interpolation (with selectable curves: Linear, Smoothstep, Ease-In/Out Quadratic, Exponential, Logarithmic), Interpolation, Aggregate (multi-input math), neighborhood tag-based access nodes, and a **Stop Event** node that pauses the simulator with a user-defined message when its flow input fires.
 - **Connection validation** — prevents incompatible connections (flow/value), cycles, and duplicate inputs; compatible ports highlight during drag
 - **Inline Port Widgets** — input ports show small value editors (number/bool) when unconnected, eliminating the need for constant nodes in simple cases
 - **Node Collapse/Expand** — double-click any node to collapse it; constants show their value; collapsed nodes temporarily expand when connecting edges
 - **Color Pickers** — Color Constant and Set Color Viewer nodes include hex color pickers with per-channel R/G/B controls
-- **Palette** — right-side panel with a drag-and-drop list of every node type (grouped by category), default macros shipped with the app (from `public/macros/*.gcamacro`), and the current project's macros
+- **Palette** — right-side panel with a drag-and-drop list of every node type (grouped by category), default macros shipped with the app (from `public/macros/*.gcamacro`), and the current project's macros. Splits vertically into independently-scrolling **Nodes** and **Macros** sections with a draggable horizontal splitter; a **List / Visual** toggle switches between a compact text list and mini node-preview cards (split position and view mode persist across sessions)
 - **Node Explorer** — searchable right-side panel (Ctrl+F to open, Esc to close) listing all placed nodes with click-to-focus
 - **Add-Node tooltips** — hover any entry in the Add Node context menu to see a short description of what it does
-- **Incomplete-config warnings** — nodes with unset required parameters (e.g., an unselected attribute/neighborhood/mapping) show an amber warning badge in the header so you can spot them at a glance
+- **Incomplete-config warnings** — nodes with unset required parameters (e.g., an unselected attribute/neighborhood/mapping) show an amber warning badge in the header so you can spot them at a glance. Macro instances bubble up internal-node warnings (recursively through nested macros), so misconfigured internals are visible without opening the macro
 - **Canvas toggles** — toggle port labels, grid lines, and snap-to-grid from buttons below zoom controls
 - **Macro System** — encapsulate node groups into reusable subgraphs with MacroInput/MacroOutput boundary nodes
 - **Undo/Redo** — Ctrl+Z / Ctrl+Shift+Z (Ctrl+Y) for node/edge operations, moves, paste, config changes
@@ -95,7 +95,7 @@ A complete GenesisCA model definition consists of:
 - **Save Project dialog** — checkboxes to include simulator controls (speed, brush, mapping, model-attribute values) and/or the full board state; choices persist across sessions
 - **Save / Load State** — save the full simulation snapshot (`.gcastate`) for experiment repeatability; load to restore a previous state. State is also embedded in `.gcaproj` for project-level persistence.
 - **Model Presets** — embed named snapshots of model-attribute values (and optionally the cell grid) in the project, listed in the left panel above Model Attributes. One-click switching between behavioral variants — ideal for generic models like MNCA where the same rules produce wildly different emergent patterns per parameter set. Include/exclude from `.gcaproj` via the Save Project dialog.
-- **Canvas controls** — LMB=brush, RMB=pan, scroll=zoom, Ctrl+LMB drag=resize brush, Ctrl+wheel=cycle input mappings, Shift+RMB=open in-page color picker at the cursor
+- **Canvas controls** — LMB=brush, RMB=pan, scroll=zoom, Ctrl+LMB drag=resize brush, Ctrl+wheel=cycle input mappings, Shift+RMB=open in-page color picker at the cursor. The stats overlay shows the cell coordinates under the cursor (or the brush footprint range when brush > 1×1)
 - **Brush tool** — configurable color (with live R/G/B channel inputs beside the picker), width/height, input mapping; visual brush cursor; Ctrl+drag interactive resize
 - **Region clipboard** — Ctrl+C/V/X on the simulator copy/paste/cut all cell attributes within the brush rectangle; paste anchors to the brush's top-left corner
 - **Viewer tabs** — horizontal bar at the top to switch between Attribute-to-Color visualization modes
@@ -122,6 +122,7 @@ A complete GenesisCA model definition consists of:
 - [Node Reference](docs/NODES_REFERENCE.md) — full catalogue of the 40+ node types, port schemas, and compile-time semantics, with Mermaid diagrams of common patterns.
 - [CA Literature Review](docs/CA_LITERATURE_REVIEW.md) — a survey of ~70 canonical cellular-automata models across physics, chemistry, biology, ecology, sociology, transport, earth sciences (geology / mining / volcanology / seismology), CS theory and cryptography, with a Top-Tier Shortlist driving GenesisCA's feature roadmap.
 - [Performance Optimization Paths](docs/PERFORMANCE_OPTIMIZATION_PATHS.md) — engine-internal notes on the JS- and WASM-compile targets and how to keep large grids fast.
+- [Huge Grid Optimizations](docs/HUGE_GRID_OPTIMIZATIONS.md) — deferred memory-scaling techniques for pushing grids past today's WebGPU ceiling: implicit neighbor lookup, tile-based dispatch, sub-word packing for bool / small-tag attributes.
 
 ---
 

--- a/docs/HUGE_GRID_OPTIMIZATIONS.md
+++ b/docs/HUGE_GRID_OPTIMIZATIONS.md
@@ -1,0 +1,281 @@
+# GenesisCA — Optimizations for Huge Grids
+
+This document captures three known memory-scaling techniques that would let
+GenesisCA push grids well beyond the current ~5000×5000 ceiling on WebGPU.
+
+It is a **deferred-work reference** — none of these are implemented today.
+Each is well-established in the wider GPU compute / cellular-automata
+literature; the trade-offs and design notes here are project-specific.
+
+**Audience:** future-self / contributors when the next "I want a 10,000² grid"
+question lands and the v1 WebGPU layout starts hitting buffer limits.
+
+---
+
+## 1. Where the limits live today
+
+Three independent ceilings stack up:
+
+| Limit | Where | Typical value |
+|---|---|---|
+| JavaScript heap (worker) | V8 (Chromium) | ~4 GB on 64-bit; lifted by Electron `--max-old-space-size` |
+| GPU storage buffer | `adapter.limits.maxStorageBufferBindingSize` | 128 MB default; up to 2 GB on modern adapters |
+| GPU VRAM | physical card | 1-2 GB (integrated) / 8-24 GB (discrete) |
+
+On the WebGPU path, the GPU buffer ceiling typically bites first. Concrete
+examples from the current layout (`src/modeler/vpl/compiler/webgpu/layout.ts`):
+
+| Resource | Formula | 1000² | 5000² | 10000² |
+|---|---|---|---|---|
+| Per-attribute buffer (read) | `cells × 4 B` | 4 MB | 100 MB | 400 MB |
+| Per-attribute buffer (write) | `cells × 4 B` (sync ping-pong) | 4 MB | 100 MB | 400 MB |
+| Colors buffer | `cells × 4 B` | 4 MB | 100 MB | 400 MB |
+| Neighbor index table — Moore (8 nbrs) | `cells × nbr_size × 4 B` | 32 MB | 800 MB | 3.2 GB ❌ |
+| Neighbor index table — MNCA (~360 nbrs) | `cells × nbr_size × 4 B` | 1.4 GB ❌ | 36 GB ❌❌ | n/a |
+
+The neighbor index table dominates on any model with non-trivial
+neighborhoods, and it grows linearly in both grid size *and* neighborhood
+size. That's the single biggest target.
+
+---
+
+## 2. Optimization paths (highest payoff first)
+
+### 2.1 Implicit / sparse neighbor lookup
+
+**Idea.** Stop storing a per-cell neighbor index table. The current layout
+precomputes `total × nbr_size` 4-byte indices (the table that can hit 36 GB
+above). For *every* lattice neighborhood — Moore, von Neumann, MNCA's
+multi-radius rings, custom user offsets — the neighbor of cell `(r, c)` at
+offset `(Δr, Δc)` is purely a function of `(r, c)` and `(Δr, Δc)`. Boundary
+treatment (torus wrap, constant sentinel) is also a function of those plus
+the boundary mode flag.
+
+**What to store instead.** Just the offsets — `nbr_size × 8 B` (a `vec2<i32>`
+pair per neighbor). Total per-model size: a few KB regardless of grid size.
+
+**What the shader does.** At each cell, compute `nbrIdx = wrap(r + Δr) ×
+width + wrap(c + Δc)` (or the constant-boundary variant) for each neighbor,
+inline. Two integer ops per neighbor lookup vs one global memory fetch from
+a multi-GB buffer.
+
+**Savings.** Catastrophic on the neighbor table — the 3.2 GB at 10000² Moore
+becomes ~64 bytes total. The 36 GB MNCA case becomes ~3 KB. The buffer
+disappears entirely.
+
+**Cost.**
+- Per-neighbor lookup goes from a single memory read to ~5 integer ops
+  (modulo, add, multiply). On modern GPUs, ALU is faster than global memory
+  for cold reads, so this is often *also* a perf win.
+- Boundary modes need a branch (or branchless `select(...)`) per neighbor.
+  Small but non-zero shader complexity.
+- User-defined irregular neighborhoods (uncommon but supported by the
+  Neighborhoods panel) still work — the offsets are just a longer list.
+  Doesn't break the abstraction.
+
+**Implementation notes.**
+- Neighbor offsets fit in a small `array<vec2<i32>>` per neighborhood,
+  uploaded once at compile time alongside model attrs.
+- The `getNeighborAttribute` family of nodes already operates by index;
+  swapping the index source from "table fetch" to "computed" is a per-node
+  emitter change.
+- Boundary mode can be baked into the shader at compile time (one shader
+  per `(boundary, sync)` combo) or branched at runtime via the model-attrs
+  uniform.
+
+**Estimated effort.** Medium — touches every neighbor-reading WGSL emitter
+in `src/modeler/vpl/compiler/webgpu/compile.ts`, plus the layout / upload
+helpers in `webgpuRuntime.ts`. Roughly the size of the array-emitter pass
+(commit `7d9dec4`).
+
+**Headline result.** 5000² → 10000² becomes feasible on adapters that can't
+allocate the index table today.
+
+---
+
+### 2.2 Tile-based dispatch with workgroup-shared memory
+
+**Idea.** Standard GPU stencil pattern. Today's step shader dispatches one
+thread per cell, and each thread independently fetches its `nbr_size`
+neighbors from global memory. Adjacent threads in the same workgroup
+overlap heavily — a 16×16 workgroup with a 3×3 neighborhood reads each cell
+~9 times across the workgroup.
+
+**What changes.** Each workgroup loads a tile of cells (e.g. 16×16) plus a
+halo (the neighborhood radius around the tile) into `var<workgroup>` shared
+memory in one cooperative pass. Then every thread reads its neighbors from
+shared memory instead of global memory. Bandwidth goes down by roughly the
+neighborhood-overlap factor.
+
+**Savings.** Doesn't shrink any buffer — this is a *throughput* optimization
+that lets you hit higher framerates at any given grid size, or run the same
+framerate with a less-capable GPU. On Wireworld-class models (small
+neighborhood, light per-cell work) the win is small. On MNCA-class models
+(huge neighborhoods, lots of overlapping reads) the win is large.
+
+**Cost.**
+- Workgroup-shared memory is bounded
+  (`adapter.limits.maxComputeWorkgroupStorageSize`, typically 16 KB - 32 KB).
+  Big neighborhoods × multi-attribute models force smaller tiles, which
+  reduces the overlap-amortization win.
+- Halo loading needs careful indexing for boundary tiles.
+- Shader complexity goes up significantly. The current single-thread-per-
+  cell pattern is much easier to maintain.
+
+**When to do this.** After §2.1 — the index-table problem dominates. Tiling
+won't help if you can't even allocate the buffer in the first place.
+
+**Implementation notes.**
+- Per-attribute tiles: each attribute the rule reads needs its own
+  workgroup-shared array. Multi-attribute models scale shared memory linearly.
+- Probably worth gating per-shader: only tile when neighborhood size and
+  per-cell read count justify it (compile-time decision based on graph
+  analysis).
+- Different tile sizes for different models — square (16×16) for Moore,
+  longer tiles for MNCA-style annular neighborhoods.
+
+**Estimated effort.** High — most invasive of the three. The step shader
+becomes meaningfully different in shape.
+
+**References.** Hwu/Kirk *Programming Massively Parallel Processors*,
+chapter on stencil computations. NVIDIA's CUDA Conway's Game of Life
+samples. Lattice-Boltzmann fluid solvers use the same pattern.
+
+---
+
+### 2.3 Sub-word packing for bool / small-tag attributes
+
+**Idea.** WGSL storage buffers can't hold `array<bool>`, `array<u8>`, or
+`array<u16>` — the smallest scalar storage type is `u32` (4 bytes). Today
+each bool cell occupies a full u32, wasting 31 bits per cell. Same for tag
+attributes with small option counts (a 4-option tag fits in 2 bits but
+takes 32).
+
+**Two granularities.**
+
+| Approach | Cells per u32 | Memory saving | Read cost | Write cost |
+|---|---|---|---|---|
+| Byte packing | 4 (bool) | 4× | 1 shift + mask | atomic CAS or 4-aligned write |
+| Bit packing | 32 (bool) | 32× | 1 shift + mask | atomic CAS |
+
+For bools, bit packing wins on memory but write atomicity is fiddly:
+neighboring threads writing to the same word need a CAS loop, since
+atomic-OR/atomic-AND with a mask doesn't compose as cleanly when mixed
+with read-modify-write. Byte packing avoids the CAS — each thread writes
+a full byte aligned to a position in the u32 — at the cost of 8× less
+saving.
+
+**Generality concern (and why it's not actually narrow).** This isn't a
+"models with one bool only" optimization — it's a *layout* choice applied
+per attribute, transparently to the rule designer. A model with 5 bool
+attrs gets the saving on each one. A model with 0 bool attrs doesn't get
+it (and isn't penalised). The same machinery generalises to small-cardinality
+tag attributes: a 4-option tag attr packs 16 cells per u32 (2 bits each).
+
+**Where it does and doesn't help.**
+- **Helps:** any model with one or more bool / small-tag attrs.
+  GoL (1 bool: alive). Wireworld (1 tag with 4 options: empty/wire/head/tail).
+  Coagulation (1 bool). Most "alive/dead state" rules.
+- **Doesn't help:** float / int / large-cardinality-tag attrs. Those need
+  their full bits and can't be compressed below u32.
+
+**Cost.**
+- Compiler complexity: the per-attribute emit needs to know which
+  packing each attr uses and emit shift/mask code accordingly. Not a model-
+  shape special case but it IS another dimension in the layout matrix
+  (currently every attr is "u32 per cell"; with packing there'd be 3-4
+  layout flavours).
+- Write semantics: bit-packed writes need atomic CAS to be race-free in
+  sync mode. This pushes complexity into every `setAttribute(boolAttr)`
+  emission. Byte packing avoids this.
+- The per-cell copy preamble (current step shader prefix) becomes
+  block-level: instead of one `attrsWrite[idx] = attrsRead[idx]` per cell,
+  you'd copy entire u32 words atomically. Cleaner overall.
+
+**Recommended starting point.** Byte packing only, restricted to bool
+attrs. 4× saving with minimal shader complexity, no atomic CAS, no
+generality drop. Bit packing and small-tag packing can be added later if
+the 4× isn't enough.
+
+**Estimated effort.** Medium — the layout and per-attr emit pattern are
+already abstractable (`WebGPULayoutAttr` describes each attr's offset and
+size). Adding a `packing: 'word' | 'byte' | 'bit'` field per attr +
+shift/mask in the read/write emitters is the bulk of the work.
+
+**Why u32 today (the constraint that's not GenesisCA-specific).** WGSL
+spec, §6.3 Storable Types: storage buffer element types must be `i32`,
+`u32`, `f32`, plus optionally `f16`/`atomic<u32>`/`atomic<i32>`/structs of
+those. There's no `u8`, `u16`, or `bool`. The 4-byte minimum is a
+WebGPU-level constraint that every WebGPU-using app accepts. So "send it
+as a boolean" isn't an option in any architecture; the choice is always
+"how many bools per u32."
+
+---
+
+## 3. Combined impact (rough order-of-magnitude)
+
+Take the worst current case: MNCA-style model (~360-cell neighborhood) at
+5000². Today's WebGPU footprint:
+
+| Resource | Current | After §2.1 | After §2.1 + §2.3 (bool packing, hypothetical) |
+|---|---|---|---|
+| Neighbor index | 36 GB ❌ | ~3 KB | ~3 KB |
+| Per-bool-attr | 100 MB | 100 MB | 25 MB |
+| Per-int-attr | 100 MB | 100 MB | 100 MB |
+| Total (1 bool + 1 int + colors) | 300 MB+ | ~204 MB | ~129 MB |
+
+The neighbor-table compression (§2.1) is the breakthrough — without it,
+huge-neighborhood models simply can't run on most adapters. The bool
+packing (§2.3) is a nice 4× on top, only relevant after §2.1 unblocks the
+basic case.
+
+§2.2 (tiling) doesn't change the table; it changes per-step throughput.
+
+---
+
+## 4. Order of attack (when and if this becomes a priority)
+
+1. **§2.1 first.** Largest absolute win, single biggest unblocker for huge
+   grids on indicator-light hardware. Doesn't change the user-facing
+   experience or any rule semantics.
+2. **§2.3 second.** Independent of §2.1. Comfortable headroom for grids
+   beyond what §2.1 alone allows. Affects only the layout/codegen, not the
+   rule designer's view.
+3. **§2.2 last.** Throughput / framerate win, not a memory-ceiling win.
+   Adds significant shader complexity for a smaller payoff than the first
+   two. Skip unless huge grids are actually working but slow.
+
+Before any of this lands, run the existing benchmark suite (see
+`PERFORMANCE_OPTIMIZATION_PATHS.md` §8) at the target grid size on the
+target hardware to confirm which ceiling is actually being hit.
+
+---
+
+## 5. Out of scope
+
+These are intentionally NOT in this doc:
+
+- **HashLife-style hierarchical chunking** for sparse / repetitive
+  patterns (works only for binary-state CAs with known stable templates;
+  doesn't fit the general-purpose layout).
+- **Multi-GPU dispatch / SLI.** WebGPU spec exposes one adapter at a time;
+  no portable multi-GPU path exists today.
+- **Off-loading compute to a server.** Out of scope per the all-client
+  constraint.
+- **Native rewrite (Rust + wgpu / native compute kernels).** A separate,
+  much larger project.
+
+---
+
+## 6. References
+
+- [WGSL spec §6.3 Storable Types](https://www.w3.org/TR/WGSL/#storable-types)
+- [WebGPU spec — Adapter Limits](https://www.w3.org/TR/webgpu/#supported-limits)
+- Hwu, Kirk, El Hajj — *Programming Massively Parallel Processors*, 4th ed.
+  (chapters on tiled stencil patterns)
+- GPU Gems 3, Chapter 37 — Game-of-Life-style cellular automata on the GPU
+- Lattice-Boltzmann GPU implementations — same neighbor-overlap-tiling
+  pattern (e.g. NVIDIA's open-source LBM samples)
+- HashLife and related techniques — Bill Gosper's original 1984 paper, and
+  Tomas Rokicki's modern HashLife implementations (for context only — not
+  proposed for adoption here)

--- a/src/help/HelpView.tsx
+++ b/src/help/HelpView.tsx
@@ -236,7 +236,13 @@ export function HelpView() {
           <ul className={styles.list}>
             <li><strong>Palette</strong> &mdash; Browse all node types (grouped by category) plus
               default macros shipped with the app (from <code>public/macros/*.gcamacro</code>) and
-              the current project's macros. Drag any item onto the canvas to add it.</li>
+              the current project's macros. Drag any item onto the canvas to add it.
+              The panel splits vertically into two independently-scrolling sections &mdash;
+              <strong>Nodes</strong> on top, <strong>Macros</strong> on the bottom &mdash;
+              with a draggable horizontal splitter between them. A <strong>List / Visual</strong>
+              toggle in the header switches the renderer between a compact text list and
+              draggable mini node previews that mirror the node visuals; both modes drag
+              identically. Both the split position and the view mode are remembered across sessions.</li>
             <li><strong>Node Explorer</strong> (<kbd className={styles.kbd}>Ctrl</kbd>+<kbd className={styles.kbd}>F</kbd>) &mdash; Search and jump to nodes
               already placed in your graph.</li>
           </ul>
@@ -246,6 +252,13 @@ export function HelpView() {
             Nodes with required parameters that are not yet set (e.g., a <em>Set Attribute</em>
             node without an attribute selected) show a small amber <strong>!</strong> badge in their
             top-right corner. Hover it to see exactly what needs configuration.
+          </p>
+          <p className={styles.p}>
+            <strong>Macro instances bubble up internal warnings:</strong> if any node inside the
+            macro (or inside a nested macro) has a configuration warning, the macro instance
+            itself also shows the badge with a tooltip like &quot;3 internal warnings (expand
+            macro to see)&quot;. This makes misconfigured internals visible without having to
+            open the macro first.
           </p>
 
           <h3 className={styles.h3}>Node Collapse &amp; Expand</h3>
@@ -344,7 +357,7 @@ export function HelpView() {
             <thead><tr><th>Node</th><th>Description</th></tr></thead>
             <tbody>
               <tr><td>Arithmetic Operator (Math)</td><td>+, -, *, /, %, sqrt, pow, abs, max, min, mean.</td></tr>
-              <tr><td>Proportion Map</td><td>Remap a value from one range to another: output = outMin + (x - inMin) * (outMax - outMin) / (inMax - inMin). Has 5 inputs: X, In Min, In Max, Out Min, Out Max.</td></tr>
+              <tr><td>Proportion Map</td><td>Remap a value from one range to another: <em>output = outMin + curve(t) * (outMax - outMin)</em> with <em>t = (x - inMin) / (inMax - inMin)</em>. Has 5 inputs (X, In Min, In Max, Out Min, Out Max) plus a <strong>curve</strong> dropdown: Linear, Smoothstep, Ease-In Quadratic, Ease-Out Quadratic, Exponential, Logarithmic. Linear keeps un-clamped extrapolation; non-linear curves clamp t to [0, 1].</td></tr>
               <tr><td>Interpolate</td><td>Linear interpolation: output = min + t * (max - min). Inputs: T (0&ndash;1), Min, Max.</td></tr>
               <tr><td>Compare (Statement)</td><td>Comparison operators: ==, !=, &gt;, &lt;, &gt;=, &lt;=, <strong>Between</strong>, and <strong>Not Between</strong>. The between-family ops reveal a Y&#8322; input and two picklists for the lower (&gt;= or &gt;) and upper (&lt;= or &lt;) interval sides; <em>Not Between</em> fires when the value is outside the interval. Replaces the common Compare + Compare + AND chain.</td></tr>
               <tr><td>Logic Operator</td><td>AND, OR, XOR, NOT on boolean values.</td></tr>
@@ -387,7 +400,7 @@ export function HelpView() {
             <tbody>
               <tr><td>Set Color Viewer</td><td>Write RGB values for an Attribute-to-Color visualization.</td></tr>
               <tr><td>Get Color Constant</td><td>Output fixed R, G, B values.</td></tr>
-              <tr><td>Color Interpolate</td><td>Linearly interpolate between two colors. Inputs: interpolation point T (0&ndash;1), From R/G/B, To R/G/B. Outputs: R, G, B. Includes color picker widgets for &quot;Color From&quot; and &quot;Color To&quot; when the per-channel ports are not connected.</td></tr>
+              <tr><td>Color Interpolate</td><td>Interpolate between two colors. Inputs: interpolation point T (0&ndash;1), From R/G/B, To R/G/B. Outputs: R, G, B. The <strong>curve</strong> dropdown controls the interpolation shape: Linear, Smoothstep, Ease-In Quadratic, Ease-Out Quadratic, Exponential, Logarithmic. Includes color picker widgets for &quot;Color From&quot; and &quot;Color To&quot; when the per-channel ports are not connected.</td></tr>
             </tbody>
           </table>
 
@@ -506,6 +519,11 @@ export function HelpView() {
             <li><strong>Scroll wheel</strong> &mdash; Zoom in/out.</li>
             <li><strong>Ctrl + left-click drag</strong> &mdash; Resize brush (horizontal = width, vertical = height).</li>
             <li><strong>Zoom buttons</strong> (+/&minus;/fit) &mdash; Bottom-left of the canvas.</li>
+            <li><strong>Hover coordinates</strong> &mdash; the top-left stats overlay shows the
+              cell currently under the cursor as <code>Cell (col, row)</code>. When the brush
+              is larger than 1&times;1, the chip switches to{' '}
+              <code>Cells (x0,y0) &rarr; (x1,y1)</code> showing the brush footprint
+              (end-inclusive indices).</li>
           </ul>
 
           <h3 className={styles.h3}>Playback</h3>

--- a/src/modeler/ModelerView.tsx
+++ b/src/modeler/ModelerView.tsx
@@ -61,24 +61,41 @@ export function ModelerView() {
     setActiveRightPanel(lastRightPanel);
   }, [lastRightPanel]);
 
-  // Ctrl+F opens Node Explorer and focuses search; Esc closes it
+  // Ctrl+F opens Node Explorer and focuses search; Space toggles Palette;
+  // Esc closes whichever right panel is open. Registered in the capture phase
+  // so the Space toggle preempts the always-mounted SimulatorView's
+  // space-to-step listener (which is in the bubble phase) when the modeler
+  // tab is active.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const ae = document.activeElement as HTMLElement | null;
+      const tag = ae?.tagName;
+      const isField = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+        || (ae?.isContentEditable ?? false);
+
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
-        const tag = (document.activeElement as HTMLElement)?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (isField) return;
         e.preventDefault();
         setActiveRightPanel('explorer');
+        setLastRightPanel('explorer');
         setTimeout(() => explorerRef.current?.focusSearch(), 50);
+      } else if ((e.key === ' ' || e.code === 'Space') && !e.repeat) {
+        // Skip when typing or when a button has focus (Space activates buttons).
+        if (isField || tag === 'BUTTON') return;
+        e.preventDefault();
+        // Block the simulator's bubble-phase space-step listener from also
+        // running on this keystroke.
+        e.stopImmediatePropagation();
+        setActiveRightPanel(prev => (prev === 'palette' ? null : 'palette'));
+        setLastRightPanel('palette');
       } else if (e.key === 'Escape' && activeRightPanel) {
         // Don't steal Esc from fields (e.g. clearing the search input first)
-        const tag = (document.activeElement as HTMLElement)?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (isField) return;
         setActiveRightPanel(null);
       }
     };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
   }, [activeRightPanel]);
 
   const PanelContent = activePanel ? panelComponents[activePanel] : null;

--- a/src/modeler/panels/NodePreview.tsx
+++ b/src/modeler/panels/NodePreview.tsx
@@ -1,0 +1,150 @@
+/**
+ * NodePreview — a passive mini visual of a node, used in the palette's
+ * "Visual" mode. Decoupled from React Flow (no <Handle>, no useReactFlow);
+ * just a div with a colored header and port stubs so the user can see what
+ * they're about to drag onto the canvas.
+ */
+
+import type { NodeTypeDef, PortDef } from '../vpl/types';
+import type { MacroDef } from '../../model/types';
+import styles from './PalettePanelContent.module.css';
+
+/** Mirrors CaNode.tsx's textColorForBg: dark text on light backgrounds (e.g.
+ *  the white event-node headers — Generation Step, Input/Output Mapping —
+ *  whose label was previously white-on-white and unreadable). */
+function textColorForBg(bgHex: string): string {
+  const hex = bgHex.replace('#', '');
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? '#1e2a3a' : '#ffffff';
+}
+
+interface PortRow {
+  label: string;
+  category: 'value' | 'flow';
+  isArray?: boolean;
+}
+
+function portsFromDef(def: NodeTypeDef): { inputs: PortRow[]; outputs: PortRow[] } {
+  const inputs: PortRow[] = [];
+  const outputs: PortRow[] = [];
+  for (const p of def.ports as PortDef[]) {
+    const row: PortRow = { label: p.label, category: p.category, isArray: p.isArray };
+    if (p.kind === 'input') inputs.push(row);
+    else outputs.push(row);
+  }
+  return { inputs, outputs };
+}
+
+function portsFromMacroDef(macroDef: MacroDef): { inputs: PortRow[]; outputs: PortRow[] } {
+  return {
+    inputs: macroDef.exposedInputs.map(p => ({ label: p.label, category: p.category })),
+    outputs: macroDef.exposedOutputs.map(p => ({ label: p.label, category: p.category })),
+  };
+}
+
+interface PreviewProps {
+  label: string;
+  color: string;
+  inputs: PortRow[];
+  outputs: PortRow[];
+  subtitle?: string;
+  description?: string;
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+}
+
+function PreviewCard(props: PreviewProps) {
+  const { label, color, inputs, outputs, subtitle, description } = props;
+  const maxRows = Math.max(inputs.length, outputs.length, 1);
+  return (
+    <div
+      className={styles.previewCard}
+      role="button"
+      tabIndex={0}
+      draggable={props.draggable !== false}
+      onDragStart={props.onDragStart}
+      title={description || label}
+    >
+      <div className={styles.previewHeader} style={{ background: color, color: textColorForBg(color) }}>
+        <span className={styles.previewLabel}>{label}</span>
+        {subtitle && <span className={styles.previewSubtitle}>{subtitle}</span>}
+      </div>
+      <div className={styles.previewBody}>
+        <div className={styles.previewPortCol}>
+          {Array.from({ length: maxRows }).map((_, i) => {
+            const p = inputs[i];
+            if (!p) return <div key={`i${i}`} className={styles.previewPortSpacer} />;
+            const dotClass = p.category === 'flow' ? styles.previewDotFlow : styles.previewDotValue;
+            return (
+              <div key={`i${i}`} className={styles.previewPortRow}>
+                <span className={`${styles.previewDot} ${dotClass}`} />
+                <span className={styles.previewPortLabel}>{p.label}{p.isArray ? '[]' : ''}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div className={`${styles.previewPortCol} ${styles.previewPortColRight}`}>
+          {Array.from({ length: maxRows }).map((_, i) => {
+            const p = outputs[i];
+            if (!p) return <div key={`o${i}`} className={styles.previewPortSpacer} />;
+            const dotClass = p.category === 'flow' ? styles.previewDotFlow : styles.previewDotValue;
+            return (
+              <div key={`o${i}`} className={`${styles.previewPortRow} ${styles.previewPortRowRight}`}>
+                <span className={styles.previewPortLabel}>{p.label}{p.isArray ? '[]' : ''}</span>
+                <span className={`${styles.previewDot} ${dotClass}`} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface NodePreviewProps {
+  def: NodeTypeDef;
+  onDragStart: (e: React.DragEvent) => void;
+}
+
+export function NodePreview({ def, onDragStart }: NodePreviewProps) {
+  const { inputs, outputs } = portsFromDef(def);
+  return (
+    <PreviewCard
+      label={def.label}
+      color={def.color}
+      inputs={inputs}
+      outputs={outputs}
+      description={def.description}
+      onDragStart={onDragStart}
+    />
+  );
+}
+
+interface MacroPreviewProps {
+  name: string;
+  description?: string;
+  macroDef?: MacroDef; // if known, render real ports; otherwise show generic macro
+  onDragStart: (e: React.DragEvent) => void;
+}
+
+const MACRO_COLOR = '#7b1fa2';
+
+export function MacroPreview({ name, description, macroDef, onDragStart }: MacroPreviewProps) {
+  const ports = macroDef
+    ? portsFromMacroDef(macroDef)
+    : { inputs: [], outputs: [] };
+  return (
+    <PreviewCard
+      label={name}
+      color={MACRO_COLOR}
+      inputs={ports.inputs}
+      outputs={ports.outputs}
+      subtitle="Macro"
+      description={description || name}
+      onDragStart={onDragStart}
+    />
+  );
+}

--- a/src/modeler/panels/PalettePanelContent.module.css
+++ b/src/modeler/panels/PalettePanelContent.module.css
@@ -29,6 +29,232 @@
   padding-right: 4px;
 }
 
+/* ── Vertical split between Nodes and Macros sections ─────────────────── */
+
+.splitContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.scrollSection {
+  flex: 1;
+  min-height: 60px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.scrollSectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 4px 6px 4px;
+  /* Solid panel-matching background so cards scrolling underneath don't bleed
+     through (sticky header would otherwise be partly transparent). */
+  background: #16213e;
+  border-bottom: 1px solid #2d4059;
+  color: #4cc9f0;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.scrollSectionHeader .sectionCount {
+  margin-left: auto;
+}
+
+.splitter {
+  flex: 0 0 6px;
+  cursor: row-resize;
+  background: #1a2535;
+  border-top: 1px solid #2d4059;
+  border-bottom: 1px solid #2d4059;
+  transition: background 0.15s;
+}
+
+.splitter:hover,
+.splitterDragging {
+  background: #4cc9f0;
+}
+
+/* ── Header row: hint + view toggle ───────────────────────────────────── */
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 2px 6px;
+}
+
+.headerRow .hint {
+  flex: 1;
+  padding: 0;
+}
+
+.viewToggle {
+  display: flex;
+  background: #0d1117;
+  border: 1px solid #2d4059;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.viewToggleButton {
+  background: transparent;
+  border: none;
+  color: #7a8a99;
+  font-size: 0.6rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.viewToggleButton:hover {
+  color: #c0c8d0;
+}
+
+.viewToggleButtonActive {
+  background: #1f3247;
+  color: #4cc9f0;
+}
+
+/* ── Visual mode: preview card grid ────────────────────────────────────── */
+
+/* Cards flow into multiple columns when the panel is wide enough; each card
+   sizes to its content (label + port labels) up to a soft cap so long labels
+   still wrap into ellipsis instead of stretching the whole row. */
+.previewGrid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.previewCard {
+  display: inline-flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  width: max-content;
+  min-width: 110px;
+  max-width: 200px;
+  background: #1a2535;
+  border: 1px solid #2d4059;
+  border-radius: 4px;
+  cursor: grab;
+  user-select: none;
+  overflow: hidden;
+  transition: border-color 0.1s, box-shadow 0.1s;
+}
+
+.previewCard:hover {
+  border-color: #4cc9f0;
+  box-shadow: 0 0 0 1px rgba(76, 201, 240, 0.2);
+}
+
+.previewCard:active {
+  cursor: grabbing;
+}
+
+.previewCard:focus-visible {
+  outline: 1px solid #4cc9f0;
+  outline-offset: 0;
+}
+
+.previewHeader {
+  padding: 3px 6px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  /* Inline color set per-card by NodePreview.tsx via textColorForBg() —
+     dark on light headers, white on dark headers. */
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.previewLabel {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.previewSubtitle {
+  font-size: 0.5rem;
+  font-weight: 500;
+  opacity: 0.75;
+}
+
+.previewBody {
+  display: flex;
+  padding: 4px 4px;
+  gap: 6px;
+  background: #131b27;
+  min-height: 18px;
+}
+
+.previewPortCol {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.previewPortColRight {
+  text-align: right;
+}
+
+.previewPortRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.55rem;
+  color: #c0c8d0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.previewPortRowRight {
+  justify-content: flex-end;
+}
+
+.previewPortLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.previewPortSpacer {
+  height: 9px;
+}
+
+.previewDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.previewDotValue {
+  background: #4cc9f0;
+}
+
+.previewDotFlow {
+  background: #ffd166;
+}
+
 .section {
   margin-bottom: 6px;
 }

--- a/src/modeler/panels/PalettePanelContent.tsx
+++ b/src/modeler/panels/PalettePanelContent.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useModel } from '../../model/ModelContext';
 import { getNodeDefsByCategory } from '../vpl/nodes/registry';
 import type { NodeTypeDef } from '../vpl/types';
 import type { GraphNode } from '../../model/types';
+import { NodePreview, MacroPreview } from './NodePreview';
 import styles from './PalettePanelContent.module.css';
 
 interface DefaultMacroEntry {
@@ -39,18 +40,84 @@ type PaletteDragPayload =
 
 export const PALETTE_DRAG_MIME = 'application/genesisca-palette';
 
+const SPLIT_LS_KEY = 'genesisca_palette_split';
+const VIEW_LS_KEY = 'genesisca_palette_view';
+
 /** Serialize a drag payload on `dataTransfer` for the GraphEditor drop handler. */
 function startDrag(e: React.DragEvent, payload: PaletteDragPayload): void {
   e.dataTransfer.setData(PALETTE_DRAG_MIME, JSON.stringify(payload));
   e.dataTransfer.effectAllowed = 'copy';
 }
 
+function readSplitRatio(): number {
+  const raw = localStorage.getItem(SPLIT_LS_KEY);
+  if (!raw) return 0.62;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0.1 || n > 0.9) return 0.62;
+  return n;
+}
+
+function readViewMode(): 'list' | 'visual' {
+  return localStorage.getItem(VIEW_LS_KEY) === 'visual' ? 'visual' : 'list';
+}
+
 export function PalettePanelContent() {
   const { model } = useModel();
   const [search, setSearch] = useState('');
   const [defaultMacros, setDefaultMacros] = useState<DefaultMacroEntry[]>([]);
-  const [sectionsCollapsed, setSectionsCollapsed] = useState<Record<string, boolean>>({});
+  const [splitRatio, setSplitRatio] = useState<number>(() => readSplitRatio());
+  const [viewMode, setViewMode] = useState<'list' | 'visual'>(() => readViewMode());
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const splitDrag = useRef<{ startY: number; startRatio: number; height: number } | null>(null);
+  const [draggingSplit, setDraggingSplit] = useState(false);
 
+  // Persist split + view state.
+  useEffect(() => {
+    localStorage.setItem(SPLIT_LS_KEY, String(splitRatio));
+  }, [splitRatio]);
+  useEffect(() => {
+    localStorage.setItem(VIEW_LS_KEY, viewMode);
+  }, [viewMode]);
+
+  // Document-level mousemove/mouseup for splitter drag.
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const drag = splitDrag.current;
+      if (!drag) return;
+      const delta = e.clientY - drag.startY;
+      const newRatio = drag.startRatio + delta / drag.height;
+      const clamped = Math.max(0.15, Math.min(0.85, newRatio));
+      setSplitRatio(clamped);
+    };
+    const onUp = () => {
+      if (splitDrag.current) {
+        splitDrag.current = null;
+        setDraggingSplit(false);
+      }
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, []);
+
+  const onSplitterMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    splitDrag.current = {
+      startY: e.clientY,
+      startRatio: splitRatio,
+      height: Math.max(rect.height, 100),
+    };
+    setDraggingSplit(true);
+    e.preventDefault();
+  };
+
+  // Fetch default macros once.
   useEffect(() => {
     let cancelled = false;
     const base = (import.meta.env.BASE_URL || '/');
@@ -72,14 +139,12 @@ export function PalettePanelContent() {
   };
   const itemMatches = (name: string, description?: string) => matches(name) || matches(description);
 
-  const toggleSection = (id: string) =>
-    setSectionsCollapsed(prev => ({ ...prev, [id]: !prev[id] }));
-
   // Node sections by category
   const nodeSections = CATEGORY_ORDER.map(cat => {
     const defs = (byCategory.get(cat) || []).filter(d => itemMatches(d.label, d.description));
     return { cat, defs };
   }).filter(s => s.defs.length > 0);
+  const totalNodeMatches = nodeSections.reduce((n, s) => n + s.defs.length, 0);
 
   const defaultMacroMatches = defaultMacros.filter(m => itemMatches(m.name, m.description));
 
@@ -105,8 +170,95 @@ export function PalettePanelContent() {
     .filter(m => usedMacroIds.has(m.id))
     .filter(m => itemMatches(m.name));
 
-  const nothingFound =
-    nodeSections.length === 0 && defaultMacroMatches.length === 0 && projectMacros.length === 0;
+  const totalMacroMatches = defaultMacroMatches.length + projectMacros.length;
+  const nothingFound = totalNodeMatches === 0 && totalMacroMatches === 0;
+
+  const topFlex = splitRatio;
+  const bottomFlex = 1 - splitRatio;
+
+  // ─── Renderers ──────────────────────────────────────────────────────────
+
+  const renderNodeItem = (def: NodeTypeDef) => {
+    const onDragStart = (e: React.DragEvent) => startDrag(e, { kind: 'node', nodeType: def.type });
+    if (viewMode === 'visual') {
+      return (
+        <NodePreview key={def.type} def={def} onDragStart={onDragStart} />
+      );
+    }
+    return (
+      <div
+        key={def.type}
+        className={styles.item}
+        role="button"
+        tabIndex={0}
+        draggable
+        onDragStart={onDragStart}
+        title={def.description || def.label}
+      >
+        <span className={styles.itemDot} style={{ background: def.color }} />
+        <div className={styles.itemBody}>
+          <div className={styles.itemLabel}>{def.label}</div>
+          {def.description && (
+            <div className={styles.itemDescription}>{def.description}</div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const renderDefaultMacroItem = (m: DefaultMacroEntry) => {
+    const onDragStart = (e: React.DragEvent) =>
+      startDrag(e, { kind: 'macro-default', macroKey: m.key, file: m.file });
+    if (viewMode === 'visual') {
+      return (
+        <MacroPreview key={m.key} name={m.name} description={m.description} onDragStart={onDragStart} />
+      );
+    }
+    return (
+      <div
+        key={m.key}
+        className={styles.item}
+        role="button"
+        tabIndex={0}
+        draggable
+        onDragStart={onDragStart}
+        title={m.description || m.name}
+      >
+        <span className={styles.itemDot} style={{ background: '#00897b' }} />
+        <div className={styles.itemBody}>
+          <div className={styles.itemLabel}>{m.name}</div>
+          {m.description && <div className={styles.itemDescription}>{m.description}</div>}
+        </div>
+      </div>
+    );
+  };
+
+  const renderProjectMacroItem = (m: { id: string; name: string }) => {
+    const macroDef = (model.macroDefs || []).find(d => d.id === m.id);
+    const onDragStart = (e: React.DragEvent) =>
+      startDrag(e, { kind: 'macro-project', macroDefId: m.id });
+    if (viewMode === 'visual') {
+      return (
+        <MacroPreview key={m.id} name={m.name} macroDef={macroDef} onDragStart={onDragStart} />
+      );
+    }
+    return (
+      <div
+        key={m.id}
+        className={styles.item}
+        role="button"
+        tabIndex={0}
+        draggable
+        onDragStart={onDragStart}
+        title={m.name}
+      >
+        <span className={styles.itemDot} style={{ background: '#00897b' }} />
+        <div className={styles.itemBody}>
+          <div className={styles.itemLabel}>{m.name}</div>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div className={styles.palette}>
@@ -117,106 +269,101 @@ export function PalettePanelContent() {
         value={search}
         onChange={e => setSearch(e.target.value)}
       />
-      <div className={styles.hint}>Drag onto the canvas to add.</div>
-      <div className={styles.list}>
-        {/* Nodes */}
-        <div className={styles.section}>
-          <button className={styles.sectionHeader} onClick={() => toggleSection('nodes')}>
-            <span className={`${styles.sectionChevron} ${sectionsCollapsed['nodes'] ? styles.sectionChevronCollapsed : ''}`}>▼</span>
-            Nodes
-            <span className={styles.sectionCount}>{nodeSections.reduce((n, s) => n + s.defs.length, 0)}</span>
-          </button>
-          {!sectionsCollapsed['nodes'] && nodeSections.map(({ cat, defs }) => (
-            <div key={cat}>
-              <div className={styles.subSectionLabel}>{CATEGORY_LABELS[cat]}</div>
-              {defs.map(def => (
-                <div
-                  key={def.type}
-                  className={styles.item}
-                  role="button"
-                  tabIndex={0}
-                  draggable
-                  onDragStart={e => startDrag(e, { kind: 'node', nodeType: def.type })}
-                  title={def.description || def.label}
-                >
-                  <span className={styles.itemDot} style={{ background: def.color }} />
-                  <div className={styles.itemBody}>
-                    <div className={styles.itemLabel}>{def.label}</div>
-                    {def.description && (
-                      <div className={styles.itemDescription}>{def.description}</div>
-                    )}
-                  </div>
+      <div className={styles.headerRow}>
+        <div className={styles.hint}>Drag onto the canvas to add.</div>
+        <div className={styles.viewToggle} role="group" aria-label="Palette view mode">
+          <button
+            type="button"
+            className={`${styles.viewToggleButton} ${viewMode === 'list' ? styles.viewToggleButtonActive : ''}`}
+            onClick={() => setViewMode('list')}
+            title="List view (compact)"
+          >List</button>
+          <button
+            type="button"
+            className={`${styles.viewToggleButton} ${viewMode === 'visual' ? styles.viewToggleButtonActive : ''}`}
+            onClick={() => setViewMode('visual')}
+            title="Visual view (mini node previews)"
+          >Visual</button>
+        </div>
+      </div>
+
+      <div className={styles.splitContainer} ref={containerRef}>
+        {/* Top — Nodes */}
+        <div
+          className={styles.scrollSection}
+          style={{ flex: `${topFlex} 1 0` }}
+        >
+          <div className={styles.scrollSectionHeader}>
+            <span>Nodes</span>
+            <span className={styles.sectionCount}>{totalNodeMatches}</span>
+          </div>
+          {viewMode === 'visual' ? (
+            <>
+              {nodeSections.map(({ cat, defs }) => (
+                <div key={cat}>
+                  <div className={styles.subSectionLabel}>{CATEGORY_LABELS[cat]}</div>
+                  <div className={styles.previewGrid}>{defs.map(renderNodeItem)}</div>
                 </div>
               ))}
+              {nodeSections.length === 0 && <div className={styles.empty}>No nodes match</div>}
+            </>
+          ) : (
+            <>
+              {nodeSections.map(({ cat, defs }) => (
+                <div key={cat}>
+                  <div className={styles.subSectionLabel}>{CATEGORY_LABELS[cat]}</div>
+                  {defs.map(renderNodeItem)}
+                </div>
+              ))}
+              {nodeSections.length === 0 && <div className={styles.empty}>No nodes match</div>}
+            </>
+          )}
+        </div>
+
+        {/* Splitter */}
+        <div
+          className={`${styles.splitter} ${draggingSplit ? styles.splitterDragging : ''}`}
+          onMouseDown={onSplitterMouseDown}
+          role="separator"
+          aria-orientation="horizontal"
+          title="Drag to resize"
+        />
+
+        {/* Bottom — Macros (default + project) */}
+        <div
+          className={styles.scrollSection}
+          style={{ flex: `${bottomFlex} 1 0` }}
+        >
+          <div className={styles.scrollSectionHeader}>
+            <span>Macros</span>
+            <span className={styles.sectionCount}>{totalMacroMatches}</span>
+          </div>
+          <div className={styles.subSectionLabel}>Default Macros</div>
+          {viewMode === 'visual' ? (
+            <div className={styles.previewGrid}>
+              {defaultMacroMatches.map(renderDefaultMacroItem)}
             </div>
-          ))}
-          {nodeSections.length === 0 && <div className={styles.empty}>No nodes match</div>}
-        </div>
-
-        {/* Default Macros */}
-        <div className={styles.section}>
-          <button className={styles.sectionHeader} onClick={() => toggleSection('default-macros')}>
-            <span className={`${styles.sectionChevron} ${sectionsCollapsed['default-macros'] ? styles.sectionChevronCollapsed : ''}`}>▼</span>
-            Default Macros
-            <span className={styles.sectionCount}>{defaultMacroMatches.length}</span>
-          </button>
-          {!sectionsCollapsed['default-macros'] && (
-            <>
-              {defaultMacroMatches.map(m => (
-                <div
-                  key={m.key}
-                  className={styles.item}
-                  role="button"
-                  tabIndex={0}
-                  draggable
-                  onDragStart={e => startDrag(e, { kind: 'macro-default', macroKey: m.key, file: m.file })}
-                  title={m.description || m.name}
-                >
-                  <span className={styles.itemDot} style={{ background: '#00897b' }} />
-                  <div className={styles.itemBody}>
-                    <div className={styles.itemLabel}>{m.name}</div>
-                    {m.description && (
-                      <div className={styles.itemDescription}>{m.description}</div>
-                    )}
-                  </div>
-                </div>
-              ))}
-              {defaultMacroMatches.length === 0 && <div className={styles.empty}>No default macros{q ? ' match' : ''}</div>}
-            </>
+          ) : (
+            defaultMacroMatches.map(renderDefaultMacroItem)
           )}
-        </div>
-
-        {/* Project Macros */}
-        <div className={styles.section}>
-          <button className={styles.sectionHeader} onClick={() => toggleSection('project-macros')}>
-            <span className={`${styles.sectionChevron} ${sectionsCollapsed['project-macros'] ? styles.sectionChevronCollapsed : ''}`}>▼</span>
-            Project Macros
-            <span className={styles.sectionCount}>{projectMacros.length}</span>
-          </button>
-          {!sectionsCollapsed['project-macros'] && (
-            <>
-              {projectMacros.map(m => (
-                <div
-                  key={m.id}
-                  className={styles.item}
-                  role="button"
-                  tabIndex={0}
-                  draggable
-                  onDragStart={e => startDrag(e, { kind: 'macro-project', macroDefId: m.id })}
-                  title={m.name}
-                >
-                  <span className={styles.itemDot} style={{ background: '#00897b' }} />
-                  <div className={styles.itemBody}>
-                    <div className={styles.itemLabel}>{m.name}</div>
-                  </div>
-                </div>
-              ))}
-              {projectMacros.length === 0 && <div className={styles.empty}>No project macros{q ? ' match' : ''}</div>}
-            </>
+          {defaultMacroMatches.length === 0 && (
+            <div className={styles.empty}>No default macros{q ? ' match' : ''}</div>
           )}
-        </div>
 
-        {nothingFound && q && <div className={styles.empty}>No results for "{search}"</div>}
+          <div className={styles.subSectionLabel}>Project Macros</div>
+          {viewMode === 'visual' ? (
+            <div className={styles.previewGrid}>
+              {projectMacros.map(renderProjectMacroItem)}
+            </div>
+          ) : (
+            projectMacros.map(renderProjectMacroItem)
+          )}
+          {projectMacros.length === 0 && (
+            <div className={styles.empty}>No project macros{q ? ' match' : ''}</div>
+          )}
+
+          {nothingFound && q && <div className={styles.empty}>No results for "{search}"</div>}
+        </div>
       </div>
     </div>
   );

--- a/src/modeler/vpl/CaNode.tsx
+++ b/src/modeler/vpl/CaNode.tsx
@@ -2,7 +2,9 @@ import { memo, useCallback, useState, useMemo, useSyncExternalStore } from 'reac
 import { Handle, Position, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { getNodeDef } from './nodes/registry';
-import { detectMissingConfig, detectWebGPUIncompatibilities } from './nodes/nodeValidation';
+import { detectMissingConfig, detectWebGPUIncompatibilities, countMacroSubgraphIssues } from './nodes/nodeValidation';
+import { INTERPOLATION_METHODS, INTERPOLATION_SHORT_LABELS, DEFAULT_INTERPOLATION_METHOD } from './nodes/interpolationMethods';
+import type { InterpolationMethod } from './nodes/interpolationMethods';
 import { handleId } from './types';
 import type { NodeConfig } from './types';
 import type { MacroPort } from '../../model/types';
@@ -302,9 +304,23 @@ function CaNodeComponent({ id, data }: NodeProps) {
   // sees them in the modeler before hitting the runtime compile error.
   const configIssues = useMemo(
     () => {
+      const useWebGPU = !!model.properties.useWebGPU;
       const base = detectMissingConfig(nodeData.nodeType, nodeData.config, model);
-      if (!model.properties.useWebGPU) return base;
-      return [...base, ...detectWebGPUIncompatibilities(nodeData.nodeType, nodeData.config, model)];
+      const own = useWebGPU
+        ? [...base, ...detectWebGPUIncompatibilities(nodeData.nodeType, nodeData.config, model)]
+        : base;
+      // Bubble up internal-node warnings on macro instances so they're visible
+      // without expanding the macro (and recursively through nested macros).
+      if (nodeData.nodeType === 'macro') {
+        const macroDefId = nodeData.config.macroDefId;
+        if (typeof macroDefId === 'string' && macroDefId.length > 0) {
+          const innerCount = countMacroSubgraphIssues(macroDefId, model, useWebGPU);
+          if (innerCount > 0) {
+            own.push(`${innerCount} internal warning${innerCount === 1 ? '' : 's'} (expand macro to see)`);
+          }
+        }
+      }
+      return own;
     },
     [
       nodeData.nodeType,
@@ -491,6 +507,12 @@ function CaNodeComponent({ id, data }: NodeProps) {
         average: 'Average', median: 'Median', and: 'AND', or: 'OR',
       };
       collapsedLabel = opLabels[op] ?? op;
+    } else if (nodeData.nodeType === 'colorInterpolation') {
+      const m = ((nodeData.config.method as string) || DEFAULT_INTERPOLATION_METHOD) as InterpolationMethod;
+      collapsedLabel = `Color Interp · ${INTERPOLATION_SHORT_LABELS[m] ?? m}`;
+    } else if (nodeData.nodeType === 'proportionMap') {
+      const m = ((nodeData.config.method as string) || DEFAULT_INTERPOLATION_METHOD) as InterpolationMethod;
+      collapsedLabel = `Prop Map · ${INTERPOLATION_SHORT_LABELS[m] ?? m}`;
     } else if (nodeData.nodeType === 'filterNeighbors') {
       const attr = model.attributes.find(a => a.id === nodeData.config.attributeId);
       const nbr = model.neighborhoods.find(n => n.id === nodeData.config.neighborhoodId);
@@ -1304,6 +1326,19 @@ function CaNodeComponent({ id, data }: NodeProps) {
             <option value="median">Median</option>
             <option value="and">AND (all true)</option>
             <option value="or">OR (any true)</option>
+          </select>
+        )}
+
+        {(nodeData.nodeType === 'colorInterpolation' || nodeData.nodeType === 'proportionMap') && (
+          <select
+            className={styles.select}
+            value={(nodeData.config.method as string) || DEFAULT_INTERPOLATION_METHOD}
+            onChange={e => updateConfig('method', e.target.value)}
+            title="Interpolation curve"
+          >
+            {INTERPOLATION_METHODS.map(m => (
+              <option key={m.value} value={m.value}>{m.label}</option>
+            ))}
           </select>
         )}
 

--- a/src/modeler/vpl/compiler/wasm/compile.ts
+++ b/src/modeler/vpl/compiler/wasm/compile.ts
@@ -300,6 +300,126 @@ function storeResult(em: WasmEmitter, valtype: ValType): LocalRef {
   return { localIdx: local, valtype };
 }
 
+/**
+ * Emit WASM that computes the interpolation curve f(t) for the given method,
+ * reading from `tRawLoc` (an f64 local containing the raw t value) and
+ * returning the f64 local that holds the curved result.
+ *
+ * For non-linear methods, t is clamped to [0, 1] before applying the curve;
+ * `linear` keeps unclamped extrapolation to match the prior bit-identical
+ * behaviour for saved models. Mirrors `emitInterpolationCurveJS` in
+ * `nodes/interpolationMethods.ts` and the WGSL variant.
+ */
+function emitInterpolationCurveWasm(
+  em: WasmEmitter,
+  tRawLoc: number,
+  method: string,
+): number {
+  const out = em.allocLocal(F64);
+  if (method === 'linear') {
+    em.localGet(tRawLoc);
+    em.localSet(out);
+    return out;
+  }
+  // Clamp t to [0, 1] using f64.max(0, f64.min(1, t)).
+  const tcl = em.allocLocal(F64);
+  em.f64Const(0);
+  em.f64Const(1);
+  em.localGet(tRawLoc);
+  em.op(OP_F64_MIN);
+  em.op(OP_F64_MAX);
+  em.localSet(tcl);
+  switch (method) {
+    case 'smoothstep': {
+      // tcl * tcl * (3 - 2 * tcl)
+      em.localGet(tcl);
+      em.localGet(tcl);
+      em.op(OP_F64_MUL);
+      em.f64Const(3);
+      em.f64Const(2);
+      em.localGet(tcl);
+      em.op(OP_F64_MUL);
+      em.op(OP_F64_SUB);
+      em.op(OP_F64_MUL);
+      em.localSet(out);
+      break;
+    }
+    case 'easeInQuad': {
+      // tcl * tcl
+      em.localGet(tcl);
+      em.localGet(tcl);
+      em.op(OP_F64_MUL);
+      em.localSet(out);
+      break;
+    }
+    case 'easeOutQuad': {
+      // 1 - (1-tcl)*(1-tcl)
+      em.f64Const(1);
+      em.f64Const(1);
+      em.localGet(tcl);
+      em.op(OP_F64_SUB);
+      em.f64Const(1);
+      em.localGet(tcl);
+      em.op(OP_F64_SUB);
+      em.op(OP_F64_MUL);
+      em.op(OP_F64_SUB);
+      em.localSet(out);
+      break;
+    }
+    case 'exponential': {
+      // tcl > 0 ? pow(2, 10*(tcl-1)) : 0
+      em.localGet(tcl);
+      em.f64Const(0);
+      em.op(OP_F64_GT);
+      em.ifThenElse(
+        () => {
+          em.f64Const(2);
+          em.f64Const(10);
+          em.localGet(tcl);
+          em.f64Const(1);
+          em.op(OP_F64_SUB);
+          em.op(OP_F64_MUL);
+          em.emit(byte(0x10), leb128u(POW_FUNC_IDX));
+          em.localSet(out);
+        },
+        () => {
+          em.f64Const(0);
+          em.localSet(out);
+        },
+      );
+      break;
+    }
+    case 'logarithmic': {
+      // tcl < 1 ? 1 - pow(2, -10*tcl) : 1
+      em.localGet(tcl);
+      em.f64Const(1);
+      em.op(OP_F64_LT);
+      em.ifThenElse(
+        () => {
+          em.f64Const(1);
+          em.f64Const(2);
+          em.f64Const(-10);
+          em.localGet(tcl);
+          em.op(OP_F64_MUL);
+          em.emit(byte(0x10), leb128u(POW_FUNC_IDX));
+          em.op(OP_F64_SUB);
+          em.localSet(out);
+        },
+        () => {
+          em.f64Const(1);
+          em.localSet(out);
+        },
+      );
+      break;
+    }
+    default:
+      em.localGet(tcl);
+      em.localSet(out);
+      break;
+  }
+  return out;
+}
+
 const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
 
   getConstant: ({ node, ctx }) => {
@@ -738,17 +858,19 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
     return emitAggregateOrCount(ctx, node, inputs, 'groupOperator');
   },
 
-  // -- proportionMap: linear remap from [inMin, inMax] to [outMin, outMax].
-  //    Result = ((inMax - inMin) !== 0)
-  //      ? outMin + (x - inMin) * (outMax - outMin) / (inMax - inMin)
-  //      : outMin
+  // -- proportionMap: remap from [inMin, inMax] to [outMin, outMax] using a
+  //    selectable curve.
+  //    Let t = (x - inMin) / (inMax - inMin) when inSpan != 0, else 0.
+  //    Result = outMin + curve(t) * (outMax - outMin) when inSpan != 0,
+  //             else outMin.
   //    All maths in f64 to match JS Number semantics.
-  proportionMap: ({ ctx, inputs }) => {
+  proportionMap: ({ ctx, node, inputs }) => {
     const x      = inputs['x']      ?? { inline: true, value: 0, valtype: F64 };
     const inMin  = inputs['inMin']  ?? { inline: true, value: 0, valtype: F64 };
     const inMax  = inputs['inMax']  ?? { inline: true, value: 1, valtype: F64 };
     const outMin = inputs['outMin'] ?? { inline: true, value: 0, valtype: F64 };
     const outMax = inputs['outMax'] ?? { inline: true, value: 1, valtype: F64 };
+    const method = (node.data.config.method as string) || 'linear';
     // Compute (inMax - inMin) into a local (used twice: zero-check + divisor).
     const inSpan = ctx.emitter.allocLocal(F64);
     pushValueAs(ctx.emitter, inMax, F64);
@@ -757,26 +879,28 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
     ctx.emitter.localSet(inSpan);
     // Result local
     const result = ctx.emitter.allocLocal(F64);
-    // if (inSpan != 0) result = outMin + (x - inMin) * (outMax - outMin) / inSpan
+    // if (inSpan != 0) result = outMin + curve(t) * (outMax - outMin)
     // else result = outMin
     ctx.emitter.localGet(inSpan);
     ctx.emitter.f64Const(0);
     ctx.emitter.op(OP_F64_NE);
     ctx.emitter.ifThenElse(
       () => {
-        // (x - inMin)
+        // tRaw = (x - inMin) / inSpan
+        const tRaw = ctx.emitter.allocLocal(F64);
         pushValueAs(ctx.emitter, x, F64);
         pushValueAs(ctx.emitter, inMin, F64);
         ctx.emitter.op(OP_F64_SUB);
-        // * (outMax - outMin)
+        ctx.emitter.localGet(inSpan);
+        ctx.emitter.op(OP_F64_DIV);
+        ctx.emitter.localSet(tRaw);
+        const tCurve = emitInterpolationCurveWasm(ctx.emitter, tRaw, method);
+        // (outMax - outMin) * tCurve + outMin
         pushValueAs(ctx.emitter, outMax, F64);
         pushValueAs(ctx.emitter, outMin, F64);
         ctx.emitter.op(OP_F64_SUB);
+        ctx.emitter.localGet(tCurve);
         ctx.emitter.op(OP_F64_MUL);
-        // / inSpan
-        ctx.emitter.localGet(inSpan);
-        ctx.emitter.op(OP_F64_DIV);
-        // + outMin
         pushValueAs(ctx.emitter, outMin, F64);
         ctx.emitter.op(OP_F64_ADD);
         ctx.emitter.localSet(result);
@@ -822,7 +946,7 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
     return rRef;
   },
 
-  // -- colorInterpolation: Math.round(c1 + t * (c2 - c1)) per channel.
+  // -- colorInterpolation: Math.round(c1 + curve(t) * (c2 - c1)) per channel.
   //    Math.round(x) = floor(x + 0.5) for the values we deal with (positive
   //    color channels in [0, 255]). --
   colorInterpolation: ({ ctx, node, inputs }) => {
@@ -833,11 +957,13 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
     const r2 = inputs['r2'] ?? { inline: true, value: 255, valtype: I32 };
     const g2 = inputs['g2'] ?? { inline: true, value: 255, valtype: I32 };
     const b2 = inputs['b2'] ?? { inline: true, value: 255, valtype: I32 };
-    const tLoc = ctx.emitter.allocLocal(F64);
+    const method = (node.data.config.method as string) || 'linear';
+    const tRaw = ctx.emitter.allocLocal(F64);
     pushValueAs(ctx.emitter, t, F64);
-    ctx.emitter.localSet(tLoc);
+    ctx.emitter.localSet(tRaw);
+    const tLoc = emitInterpolationCurveWasm(ctx.emitter, tRaw, method);
     const emitCh = (c1: ValueRef, c2: ValueRef): LocalRef => {
-      // floor(c1 + t * (c2 - c1) + 0.5) → i32
+      // floor(c1 + curveT * (c2 - c1) + 0.5) → i32
       pushValueAs(ctx.emitter, c1, F64);
       ctx.emitter.localGet(tLoc);
       pushValueAs(ctx.emitter, c2, F64);

--- a/src/modeler/vpl/compiler/webgpu/compile.ts
+++ b/src/modeler/vpl/compiler/webgpu/compile.ts
@@ -196,6 +196,37 @@ function emitLet(ctx: CompileCtx, type: WgslType, expr: string, prefix: string =
   ctx.lines.push(`  let ${name}: ${type} = ${expr};`);
   return { expr: name, type };
 }
+
+/**
+ * Build a WGSL expression that computes the interpolation curve f(t) for the
+ * given method. Mirrors `emitInterpolationCurveJS` in
+ * `nodes/interpolationMethods.ts` and the WASM variant.
+ *
+ * For non-linear methods, t is clamped to [0, 1] before applying the curve;
+ * `linear` keeps unclamped extrapolation to match the JS / WASM behaviour.
+ */
+function wgslInterpolationCurveExpr(tExpr: string, method: string): string {
+  if (method === 'linear') return `(${tExpr})`;
+  const tcl = `clamp((${tExpr}), 0.0, 1.0)`;
+  switch (method) {
+    case 'smoothstep':
+      // Use a let to evaluate clamp once. We inline via a function-call to a
+      // builtin pattern — wrap the body in a select-free expression.
+      return `(${tcl}) * (${tcl}) * (3.0 - 2.0 * (${tcl}))`;
+    case 'easeInQuad':
+      return `(${tcl}) * (${tcl})`;
+    case 'easeOutQuad':
+      return `(1.0 - (1.0 - (${tcl})) * (1.0 - (${tcl})))`;
+    case 'exponential':
+      // tcl > 0 ? pow(2, 10*(tcl-1)) : 0
+      return `select(0.0, pow(2.0, 10.0 * ((${tcl}) - 1.0)), (${tcl}) > 0.0)`;
+    case 'logarithmic':
+      // tcl < 1 ? 1 - pow(2, -10*tcl) : 1
+      return `select(1.0, (1.0 - pow(2.0, -10.0 * (${tcl}))), (${tcl}) < 1.0)`;
+    default:
+      return `(${tcl})`;
+  }
+}
 function emitVar(ctx: CompileCtx, type: WgslType, expr: string, prefix: string = 'v'): { name: string; type: WgslType } {
   const name = fresh(ctx, prefix);
   ctx.lines.push(`  var ${name}: ${type} = ${expr};`);
@@ -845,14 +876,20 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
     return emitLet(ctx, r.type, r.expr, 'nbAtr');
   },
 
-  proportionMap: ({ ctx, inputs }) => {
+  proportionMap: ({ ctx, node, inputs }) => {
     const x = castTo(inputs['x'] ?? { expr: '0.0', type: 'f32' }, 'f32');
     const inMin = castTo(inputs['inMin'] ?? { expr: '0.0', type: 'f32' }, 'f32');
     const inMax = castTo(inputs['inMax'] ?? { expr: '1.0', type: 'f32' }, 'f32');
     const outMin = castTo(inputs['outMin'] ?? { expr: '0.0', type: 'f32' }, 'f32');
     const outMax = castTo(inputs['outMax'] ?? { expr: '1.0', type: 'f32' }, 'f32');
+    const method = (node.data.config.method as string) || 'linear';
     const span = emitLet(ctx, 'f32', `(${inMax} - ${inMin})`, 'sp');
-    const expr = `select((${outMin}), ((${outMin}) + ((${x}) - (${inMin})) * ((${outMax}) - (${outMin})) / ${span.expr}), (${span.expr} != 0.0))`;
+    // tRaw = inSpan != 0 ? (x-inMin)/inSpan : 0
+    const tRawExpr = `select(0.0, ((${x}) - (${inMin})) / ${span.expr}, (${span.expr} != 0.0))`;
+    const tRaw = emitLet(ctx, 'f32', tRawExpr, 'pmt');
+    const tCurveExpr = wgslInterpolationCurveExpr(tRaw.expr, method);
+    const tCurve = emitLet(ctx, 'f32', tCurveExpr, 'pmc');
+    const expr = `select((${outMin}), ((${outMin}) + ${tCurve.expr} * ((${outMax}) - (${outMin}))), (${span.expr} != 0.0))`;
     return emitLet(ctx, 'f32', expr, 'pm');
   },
 
@@ -878,7 +915,9 @@ const VALUE_NODE_EMITTERS: Record<string, NodeValueEmitter> = {
 
   colorInterpolation: ({ ctx, node, inputs }) => {
     const t = castTo(inputs['t'] ?? { expr: '0.5', type: 'f32' }, 'f32');
-    const tLoc = emitLet(ctx, 'f32', t, 'ct');
+    const method = (node.data.config.method as string) || 'linear';
+    const tRaw = emitLet(ctx, 'f32', t, 'cit');
+    const tLoc = emitLet(ctx, 'f32', wgslInterpolationCurveExpr(tRaw.expr, method), 'cic');
     const ch = (c1k: string, c2k: string, def1: number, def2: number, port: 'r' | 'g' | 'b'): ValueRef => {
       const c1 = castTo(inputs[c1k] ?? { expr: `${def1 | 0}`, type: 'i32' }, 'f32');
       const c2 = castTo(inputs[c2k] ?? { expr: `${def2 | 0}`, type: 'i32' }, 'f32');

--- a/src/modeler/vpl/nodes/ColorInterpolationNode.ts
+++ b/src/modeler/vpl/nodes/ColorInterpolationNode.ts
@@ -1,9 +1,14 @@
 import type { NodeTypeDef } from '../types';
+import {
+  DEFAULT_INTERPOLATION_METHOD,
+  curvedTVarName,
+  emitInterpolationCurveJS,
+} from './interpolationMethods';
 
 export const ColorInterpolationNode: NodeTypeDef = {
   type: 'colorInterpolation',
   label: 'Color Interpolate',
-  description: 'Linearly interpolates between two RGB colors using T in [0, 1].',
+  description: 'Interpolates between two RGB colors using T in [0, 1] with a selectable curve.',
   category: 'color',
   color: '#006064',
   ports: [
@@ -18,8 +23,8 @@ export const ColorInterpolationNode: NodeTypeDef = {
     { id: 'g', label: 'G', kind: 'output', category: 'value', dataType: 'integer' },
     { id: 'b', label: 'B', kind: 'output', category: 'value', dataType: 'integer' },
   ],
-  defaultConfig: {},
-  compile: (nodeId, _config, inputs) => {
+  defaultConfig: { method: DEFAULT_INTERPOLATION_METHOD },
+  compile: (nodeId, config, inputs) => {
     const t = inputs['t'] || '0.5';
     const r1 = inputs['r1'] || '0';
     const g1 = inputs['g1'] || '0';
@@ -27,10 +32,14 @@ export const ColorInterpolationNode: NodeTypeDef = {
     const r2 = inputs['r2'] || '255';
     const g2 = inputs['g2'] || '255';
     const b2 = inputs['b2'] || '255';
+    const method = (config.method as string) || DEFAULT_INTERPOLATION_METHOD;
+    const curveSetup = emitInterpolationCurveJS(nodeId, t, method);
+    const tf = curvedTVarName(nodeId);
     return [
-      `const _v${nodeId}_r = Math.round((${r1}) + (${t}) * ((${r2}) - (${r1})));`,
-      `const _v${nodeId}_g = Math.round((${g1}) + (${t}) * ((${g2}) - (${g1})));`,
-      `const _v${nodeId}_b = Math.round((${b1}) + (${t}) * ((${b2}) - (${b1})));`,
+      curveSetup,
+      `const _v${nodeId}_r = Math.round((${r1}) + ${tf} * ((${r2}) - (${r1})));`,
+      `const _v${nodeId}_g = Math.round((${g1}) + ${tf} * ((${g2}) - (${g1})));`,
+      `const _v${nodeId}_b = Math.round((${b1}) + ${tf} * ((${b2}) - (${b1})));`,
     ].join(' ') + '\n';
   },
 };

--- a/src/modeler/vpl/nodes/ProportionMapNode.ts
+++ b/src/modeler/vpl/nodes/ProportionMapNode.ts
@@ -1,9 +1,14 @@
 import type { NodeTypeDef } from '../types';
+import {
+  DEFAULT_INTERPOLATION_METHOD,
+  curvedTVarName,
+  emitInterpolationCurveJS,
+} from './interpolationMethods';
 
 export const ProportionMapNode: NodeTypeDef = {
   type: 'proportionMap',
   label: 'Proportion Map',
-  description: 'Linearly maps X from one range to another (inMin\u2013inMax \u2192 outMin\u2013outMax).',
+  description: 'Maps X from one range to another using a selectable interpolation curve.',
   category: 'logic',
   color: '#b8860b',
   ports: [
@@ -14,13 +19,18 @@ export const ProportionMapNode: NodeTypeDef = {
     { id: 'outMax', label: 'Out Max', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '1' },
     { id: 'result', label: 'Result', kind: 'output', category: 'value', dataType: 'any' },
   ],
-  defaultConfig: {},
-  compile: (nodeId, _config, inputs) => {
+  defaultConfig: { method: DEFAULT_INTERPOLATION_METHOD },
+  compile: (nodeId, config, inputs) => {
     const x = inputs['x'] || '0';
     const inMin = inputs['inMin'] || '0';
     const inMax = inputs['inMax'] || '1';
     const outMin = inputs['outMin'] || '0';
     const outMax = inputs['outMax'] || '1';
-    return `const _v${nodeId} = ((${inMax}) - (${inMin})) !== 0 ? (${outMin}) + ((${x}) - (${inMin})) * ((${outMax}) - (${outMin})) / ((${inMax}) - (${inMin})) : (${outMin});\n`;
+    const method = (config.method as string) || DEFAULT_INTERPOLATION_METHOD;
+    // Raw t = (x - inMin) / (inMax - inMin), guarded against zero span.
+    const tRawExpr = `((${inMax}) - (${inMin})) !== 0 ? ((${x}) - (${inMin})) / ((${inMax}) - (${inMin})) : 0`;
+    const curveSetup = emitInterpolationCurveJS(nodeId, tRawExpr, method);
+    const tf = curvedTVarName(nodeId);
+    return `${curveSetup} const _v${nodeId} = ((${inMax}) - (${inMin})) !== 0 ? (${outMin}) + ${tf} * ((${outMax}) - (${outMin})) : (${outMin});\n`;
   },
 };

--- a/src/modeler/vpl/nodes/SetIndicatorNode.ts
+++ b/src/modeler/vpl/nodes/SetIndicatorNode.ts
@@ -5,7 +5,7 @@ export const SetIndicatorNode: NodeTypeDef = {
   label: 'Set Indicator',
   description: 'Assigns a value to a standalone indicator.',
   category: 'output',
-  color: '#00695c',
+  color: '#5c427c',
   ports: [
     { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
     { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },

--- a/src/modeler/vpl/nodes/UpdateIndicatorNode.ts
+++ b/src/modeler/vpl/nodes/UpdateIndicatorNode.ts
@@ -5,7 +5,7 @@ export const UpdateIndicatorNode: NodeTypeDef = {
   label: 'Update Indicator',
   description: 'Modifies an indicator in place: increment, decrement, toggle, min/max, next/previous tag.',
   category: 'output',
-  color: '#00695c',
+  color: '#5c427c',
   ports: [
     { id: 'do', label: 'DO', kind: 'input', category: 'flow' },
     { id: 'value', label: 'Value', kind: 'input', category: 'value', dataType: 'any', inlineWidget: 'number', defaultValue: '0' },

--- a/src/modeler/vpl/nodes/interpolationMethods.ts
+++ b/src/modeler/vpl/nodes/interpolationMethods.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared interpolation curve metadata used by ColorInterpolation and
+ * ProportionMap. The same `value` strings are read by all three compile
+ * targets (JS, WASM, WebGPU); keep the lists here in sync.
+ *
+ * Curve domain is `t ∈ [0, 1]`. Linear keeps un-clamped extrapolation so
+ * older saved models behave bit-identically; every other method clamps t
+ * to [0, 1] before applying the curve.
+ */
+
+export type InterpolationMethod =
+  | 'linear'
+  | 'smoothstep'
+  | 'easeInQuad'
+  | 'easeOutQuad'
+  | 'exponential'
+  | 'logarithmic';
+
+export const INTERPOLATION_METHODS: { value: InterpolationMethod; label: string }[] = [
+  { value: 'linear',       label: 'Linear' },
+  { value: 'smoothstep',   label: 'Smoothstep' },
+  { value: 'easeInQuad',   label: 'Ease-In Quadratic' },
+  { value: 'easeOutQuad',  label: 'Ease-Out Quadratic' },
+  { value: 'exponential',  label: 'Exponential' },
+  { value: 'logarithmic',  label: 'Logarithmic' },
+];
+
+export const DEFAULT_INTERPOLATION_METHOD: InterpolationMethod = 'linear';
+
+/** Short labels used in collapsed-node display. */
+export const INTERPOLATION_SHORT_LABELS: Record<InterpolationMethod, string> = {
+  linear: 'Linear',
+  smoothstep: 'Smooth',
+  easeInQuad: 'Ease-In',
+  easeOutQuad: 'Ease-Out',
+  exponential: 'Expo',
+  logarithmic: 'Log',
+};
+
+/**
+ * Emit JS that declares `_v{nodeId}_tf` holding the curved `t` value
+ * (and any helper locals it needs). Caller then references `_v{nodeId}_tf`
+ * directly. Variable names follow the `_v{id}_*` convention so macro
+ * inlining's prefix-replace catches them.
+ */
+export function emitInterpolationCurveJS(
+  nodeId: string,
+  rawTExpr: string,
+  method: InterpolationMethod | string,
+): string {
+  const tRaw = `_v${nodeId}_traw`;
+  const tcl = `_v${nodeId}_tcl`;
+  const tf = `_v${nodeId}_tf`;
+  const head = `const ${tRaw} = (${rawTExpr});`;
+  switch (method) {
+    case 'smoothstep':
+      return `${head} const ${tcl} = Math.max(0, Math.min(1, ${tRaw})); const ${tf} = ${tcl} * ${tcl} * (3 - 2 * ${tcl});`;
+    case 'easeInQuad':
+      return `${head} const ${tcl} = Math.max(0, Math.min(1, ${tRaw})); const ${tf} = ${tcl} * ${tcl};`;
+    case 'easeOutQuad':
+      return `${head} const ${tcl} = Math.max(0, Math.min(1, ${tRaw})); const ${tf} = 1 - (1 - ${tcl}) * (1 - ${tcl});`;
+    case 'exponential':
+      return `${head} const ${tcl} = Math.max(0, Math.min(1, ${tRaw})); const ${tf} = ${tcl} <= 0 ? 0 : Math.pow(2, 10 * (${tcl} - 1));`;
+    case 'logarithmic':
+      return `${head} const ${tcl} = Math.max(0, Math.min(1, ${tRaw})); const ${tf} = ${tcl} >= 1 ? 1 : 1 - Math.pow(2, -10 * ${tcl});`;
+    case 'linear':
+    default:
+      return `${head} const ${tf} = ${tRaw};`;
+  }
+}
+
+/** Variable name carrying the curved `t` after `emitInterpolationCurveJS`. */
+export function curvedTVarName(nodeId: string): string {
+  return `_v${nodeId}_tf`;
+}

--- a/src/modeler/vpl/nodes/nodeValidation.ts
+++ b/src/modeler/vpl/nodes/nodeValidation.ts
@@ -136,6 +136,48 @@ export function detectMissingConfig(
   return issues;
 }
 
+/**
+ * Walk a macro's subgraph and return the total count of internal-node
+ * configuration warnings (and, if `useWebGPU`, WebGPU incompatibilities).
+ *
+ * Recurses into nested macros up to `MAX_MACRO_DEPTH` (mirrors the macro
+ * inliner's recursion guard in `compiler/compile.ts`). Boundary nodes
+ * (`macroInput`, `macroOutput`) and structural-only nodes (`commentNode`,
+ * `groupNode`) carry no validateable config and are skipped.
+ *
+ * Used by CaNode to "bubble up" warnings from internal nodes onto the macro
+ * instance's amber `!` badge, so misconfigurations are visible without
+ * expanding the macro.
+ */
+const MAX_MACRO_DEPTH = 20;
+
+export function countMacroSubgraphIssues(
+  macroDefId: string,
+  model: CAModel,
+  useWebGPU: boolean,
+  depth: number = 0,
+): number {
+  if (depth > MAX_MACRO_DEPTH) return 0;
+  const def = (model.macroDefs || []).find(m => m.id === macroDefId);
+  if (!def) return 0;
+  let count = 0;
+  for (const node of def.nodes) {
+    const t = node.data?.nodeType;
+    if (!t) continue;
+    if (t === 'macroInput' || t === 'macroOutput' || t === 'commentNode' || t === 'groupNode') continue;
+    const cfg = node.data.config || {};
+    count += detectMissingConfig(t, cfg, model).length;
+    if (useWebGPU) count += detectWebGPUIncompatibilities(t, cfg, model).length;
+    if (t === 'macro') {
+      const innerId = cfg.macroDefId;
+      if (typeof innerId === 'string' && innerId.length > 0) {
+        count += countMacroSubgraphIssues(innerId, model, useWebGPU, depth + 1);
+      }
+    }
+  }
+  return count;
+}
+
 /** Wave 3 — return WebGPU-target-specific issues for a node configuration.
  *
  *  WebGPU runs cells in parallel on the GPU, so any rule whose result depends

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -206,6 +206,15 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
   // canvas. Set in initWorkerWithDimensions; cleared in the
   // useWebGPUStatus handler after the canvas is sent.
   const pendingCanvasAttach = useRef<boolean>(false);
+  // Holds the about-to-be-direct-render canvas between the moment we send
+  // attachCanvas to the worker and the moment the worker confirms direct
+  // render is live (second useWebGPUStatus { ready: true, directRender: true }).
+  // Until that ack arrives we keep srcCanvasRef pointing at the regular 2D
+  // canvas (which has the latest JS-fallback putImageData content) so draw()
+  // doesn't flash blank. If the ack never arrives (worker rejected attach,
+  // or the runtime was destroyed before processing it), the placeholder
+  // canvas stays orphaned and we stay on the JS-fallback path.
+  const pendingDirectRenderCanvas = useRef<HTMLCanvasElement | null>(null);
 
   // Build full code display from all compiled functions
   const buildFullCode = useCallback((result: ReturnType<typeof compileGraph>) => {
@@ -626,6 +635,17 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       );
     }
 
+    // One-shot colors snapshot — used by handleScreenshot under direct render
+    // (where the placeholder srcCanvas can't be read on the main thread).
+    if (msg.type === 'colorsSnapshot') {
+      const cb = screenshotPendingRef.current;
+      if (cb && msg.tag === 'screenshot') {
+        screenshotPendingRef.current = null;
+        cb({ w: msg.w as number, h: msg.h as number, colors: msg.colors as Uint8ClampedArray | undefined });
+      }
+      return;
+    }
+
     // Restore simulation state from loaded .gcaproj (after worker init completes)
     if (msg.type === 'stepped' && pendingSimStateRestore.current) {
       const state = pendingSimStateRestore.current;
@@ -633,14 +653,33 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       applySimulationState(state);
     }
 
-    // P7 deferred attach: when the worker confirms WebGPU is up AND we still
-    // owe it a canvas, do the transferControlToOffscreen + attachCanvas
-    // postMessage now. Only the FIRST ready per worker triggers the transfer
-    // (pendingCanvasAttach.current gates it). After the swap, draw() switches
-    // from the JS-fallback putImageData path to the direct-render drawImage
-    // path automatically (directRenderActiveRef flips with srcCanvasRef).
+    // P7 deferred attach: a two-phase handshake with the worker so we never
+    // claim direct render before it's actually live.
+    //
+    //   Phase 1 — useWebGPUStatus { ready: true, directRender: false }:
+    //     Worker has its WebGPU runtime up but no canvas yet. We allocate a
+    //     fresh canvas, transferControlToOffscreen, and ship it via
+    //     attachCanvas. We do NOT swap srcCanvasRef yet — keep the existing
+    //     regular 2D canvas (with its JS-fallback putImageData content) so
+    //     draw() doesn't flash blank during the GPU's first present.
+    //
+    //   Phase 2 — useWebGPUStatus { ready: true, directRender: true }:
+    //     Worker has wired the canvas in setupDirectRender and dispatched the
+    //     first present. NOW we swap srcCanvasRef to the transferred canvas
+    //     and flip directRenderActiveRef. Subsequent draw() reads GPU output.
+    //
+    // If Phase 2 never arrives (attachCanvas rejected, runtime destroyed in
+    // a race), the transferred canvas stays orphaned in pendingDirectRenderCanvas
+    // and we stay permanently on JS-fallback — graceful degradation.
     if (msg.type === 'useWebGPUStatus') {
-      if (msg.ready && pendingCanvasAttach.current) {
+      if (msg.ready && msg.directRender && pendingDirectRenderCanvas.current) {
+        // Phase 2 ack — commit the swap.
+        srcCanvasRef.current = pendingDirectRenderCanvas.current;
+        pendingDirectRenderCanvas.current = null;
+        directRenderActiveRef.current = true;
+      } else if (msg.ready && pendingCanvasAttach.current) {
+        // Phase 1 ack — send attachCanvas, stash the fresh canvas, but DON'T
+        // swap srcCanvasRef or set directRenderActiveRef yet.
         pendingCanvasAttach.current = false;
         try {
           const fresh = document.createElement('canvas');
@@ -653,19 +692,18 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
             { type: 'attachCanvas', canvas: offscreen, width: fresh.width, height: fresh.height },
             [offscreen],
           );
-          srcCanvasRef.current = fresh;
-          directRenderActiveRef.current = true;
+          pendingDirectRenderCanvas.current = fresh;
         } catch (e) {
           // eslint-disable-next-line no-console
           console.warn('[webgpu] deferred OffscreenCanvas transfer failed; staying on readback path:', e);
           directRenderActiveRef.current = false;
+          pendingDirectRenderCanvas.current = null;
         }
       } else if (msg.ready === false) {
-        // Worker reports WebGPU is not ready (init failure or downgrade).
-        // If we already attached a canvas, the transferred canvas is dead and
-        // we can't putImageData onto it — but at least the flag now reflects
-        // reality so future fixes (spare canvas, etc) have a hook.
+        // Worker reports WebGPU is off (init failure or explicit downgrade).
+        // Drop any pending direct-render canvas so we don't apply it later.
         directRenderActiveRef.current = false;
+        pendingDirectRenderCanvas.current = null;
       }
     }
   };
@@ -771,6 +809,7 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
     // grid even while the worker was correctly evolving CPU state.
     directRenderActiveRef.current = false;
     pendingCanvasAttach.current = false;
+    pendingDirectRenderCanvas.current = null;
     // Drop any prior srcCanvas reference — if the previous worker init went
     // through the direct-render path, srcCanvasRef holds a transferred canvas
     // whose 2D context is permanently unavailable. Re-using it here would
@@ -1576,12 +1615,16 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
     workerRef.current?.postMessage({ type: 'updateModelAttrs', attrs: { [attrId]: value } });
   };
 
-  // F4: Screenshot export — 1:1 pixel-perfect from source canvas (no scaling)
+  // F4: Screenshot export — 1:1 pixel-perfect from source canvas (no scaling).
+  // Under WebGPU direct render the placeholder srcCanvas's 2D context is gone
+  // (transferred to the worker), so toBlob/getImageData all fail. Ask the
+  // worker for a fresh colors snapshot, paint it onto an offscreen 2D canvas,
+  // then toBlob from there. Falls through to direct toBlob in JS/WASM modes.
+  const screenshotPendingRef = useRef<((data: { w: number; h: number; colors?: Uint8ClampedArray }) => void) | null>(null);
   const handleScreenshot = () => {
-    const src = srcCanvasRef.current;
-    if (!src) return;
-    src.toBlob(blob => {
-      if (!blob) return;
+    const w = gridWidth.current;
+    const h = gridHeight.current;
+    const downloadBlob = (blob: Blob) => {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       const name = model.properties.name.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '') || 'genesis';
@@ -1589,7 +1632,25 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       a.download = `${name}_gen${generationRef.current}.png`;
       a.click();
       URL.revokeObjectURL(url);
-    }, 'image/png');
+    };
+    if (directRenderActiveRef.current) {
+      if (!workerRef.current || !w || !h) return;
+      screenshotPendingRef.current = ({ w: cw, h: ch, colors }) => {
+        if (!colors || colors.length < cw * ch * 4) return;
+        const off = document.createElement('canvas');
+        off.width = cw; off.height = ch;
+        const ctx = off.getContext('2d');
+        if (!ctx) return;
+        const imageData = new ImageData(new Uint8ClampedArray(colors), cw, ch);
+        ctx.putImageData(imageData, 0, 0);
+        off.toBlob(blob => { if (blob) downloadBlob(blob); }, 'image/png');
+      };
+      workerRef.current.postMessage({ type: 'requestColorsSnapshot', tag: 'screenshot' });
+      return;
+    }
+    const src = srcCanvasRef.current;
+    if (!src) return;
+    src.toBlob(blob => { if (blob) downloadBlob(blob); }, 'image/png');
   };
 
   // Save simulation state

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -166,6 +166,12 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
   const isPanning = useRef(false);
   const lastMouse = useRef({ x: 0, y: 0 });
   const cursorGrid = useRef<{ row: number; col: number } | null>(null);
+  /** Cell coordinates / brush rect under the cursor. State (not a ref) so the
+   *  overlay re-renders, but only updated when the integer cell or brush
+   *  dimensions change to keep mousemove cheap. */
+  const [hoverCellInfo, setHoverCellInfo] = useState<{
+    col: number; row: number; x0: number; y0: number; x1: number; y1: number;
+  } | null>(null);
   const lastPaintGrid = useRef<{ row: number; col: number } | null>(null);
   // Paint coalescing: instead of posting a paint message per mouse-move event
   // (~50-200/sec on a fast brush drag), collect cells in a buffer and flush
@@ -1231,6 +1237,26 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       // Update brush cursor position
       const gridPos = screenToGrid(e.clientX, e.clientY);
       cursorGrid.current = gridPos;
+      // Update the hover-coords chip — only when the integer cell or brush
+      // dimensions change, so React re-renders are coarse-grained.
+      const bw = brushWRef.current;
+      const bh = brushHRef.current;
+      if (gridPos) {
+        const halfW = Math.floor((bw - 1) / 2);
+        const halfH = Math.floor((bh - 1) / 2);
+        const x0 = gridPos.col - halfW;
+        const y0 = gridPos.row - halfH;
+        const x1 = x0 + bw - 1;
+        const y1 = y0 + bh - 1;
+        setHoverCellInfo(prev =>
+          prev && prev.col === gridPos.col && prev.row === gridPos.row
+            && prev.x0 === x0 && prev.y0 === y0 && prev.x1 === x1 && prev.y1 === y1
+            ? prev
+            : { col: gridPos.col, row: gridPos.row, x0, y0, x1, y1 }
+        );
+      } else {
+        setHoverCellInfo(prev => (prev === null ? prev : null));
+      }
       if (!isPanning.current && !(e.buttons & 1) && !isResizingBrush.active) draw();
 
       // Ctrl+LMB drag = resize brush
@@ -1280,7 +1306,11 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       e.preventDefault();
     };
 
-    const handleMouseLeave = () => { cursorGrid.current = null; draw(); };
+    const handleMouseLeave = () => {
+      cursorGrid.current = null;
+      setHoverCellInfo(prev => (prev === null ? prev : null));
+      draw();
+    };
 
     container.addEventListener('wheel', handleWheel, { passive: false });
     container.addEventListener('mousedown', handleMouseDown);
@@ -1943,6 +1973,11 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
           <span>{gridWidth.current || simWidth}&times;{gridHeight.current || simHeight}</span>
           <span>{actualFps} FPS</span>
           <span>{actualGps} g/s</span>
+          {hoverCellInfo && (
+            (hoverCellInfo.x0 === hoverCellInfo.x1 && hoverCellInfo.y0 === hoverCellInfo.y1)
+              ? <span title="Hovered cell">Cell ({hoverCellInfo.col}, {hoverCellInfo.row})</span>
+              : <span title="Brush footprint at the hovered cell">Cells ({hoverCellInfo.x0},{hoverCellInfo.y0}) {'\u2192'} ({hoverCellInfo.x1},{hoverCellInfo.y1})</span>
+          )}
           {recording && <span style={{ color: '#e05050' }}>{'\u23FA'} REC {recordFrameCount}f</span>}
         </div>
 

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -198,6 +198,14 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
   // it, so draw() must skip the putImageData step and only do the
   // zoom/pan drawImage. Reset when the worker is reinitialised.
   const directRenderActiveRef = useRef<boolean>(false);
+  // True between worker init and the first useWebGPUStatus { ready: true }
+  // message: signals that we still owe the worker a canvas transfer once it
+  // confirms WebGPU is up. We defer the transfer (rather than doing it
+  // optimistically at init time) so the JS-fallback period during async
+  // device acquisition can still draw via putImageData on a regular 2D
+  // canvas. Set in initWorkerWithDimensions; cleared in the
+  // useWebGPUStatus handler after the canvas is sent.
+  const pendingCanvasAttach = useRef<boolean>(false);
 
   // Build full code display from all compiled functions
   const buildFullCode = useCallback((result: ReturnType<typeof compileGraph>) => {
@@ -624,6 +632,42 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       pendingSimStateRestore.current = null;
       applySimulationState(state);
     }
+
+    // P7 deferred attach: when the worker confirms WebGPU is up AND we still
+    // owe it a canvas, do the transferControlToOffscreen + attachCanvas
+    // postMessage now. Only the FIRST ready per worker triggers the transfer
+    // (pendingCanvasAttach.current gates it). After the swap, draw() switches
+    // from the JS-fallback putImageData path to the direct-render drawImage
+    // path automatically (directRenderActiveRef flips with srcCanvasRef).
+    if (msg.type === 'useWebGPUStatus') {
+      if (msg.ready && pendingCanvasAttach.current) {
+        pendingCanvasAttach.current = false;
+        try {
+          const fresh = document.createElement('canvas');
+          fresh.width = gridWidth.current;
+          fresh.height = gridHeight.current;
+          const offscreen = (fresh as HTMLCanvasElement & {
+            transferControlToOffscreen: () => OffscreenCanvas;
+          }).transferControlToOffscreen();
+          workerRef.current?.postMessage(
+            { type: 'attachCanvas', canvas: offscreen, width: fresh.width, height: fresh.height },
+            [offscreen],
+          );
+          srcCanvasRef.current = fresh;
+          directRenderActiveRef.current = true;
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.warn('[webgpu] deferred OffscreenCanvas transfer failed; staying on readback path:', e);
+          directRenderActiveRef.current = false;
+        }
+      } else if (msg.ready === false) {
+        // Worker reports WebGPU is not ready (init failure or downgrade).
+        // If we already attached a canvas, the transferred canvas is dead and
+        // we can't putImageData onto it — but at least the flag now reflects
+        // reality so future fixes (spare canvas, etc) have a hook.
+        directRenderActiveRef.current = false;
+      }
+    }
   };
 
   // Reusable worker initializer (used by structural effect and dimension/image apply)
@@ -716,40 +760,34 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
         return { shaderCode: '', entryPoints: { step: 'step', outputMappings: [] as Array<{ mappingId: string; entry: string }> }, layout: null as never, error: String((e as Error)?.message || e) };
       }
     })();
-    // P7 direct render: when WebGPU is the chosen target AND OffscreenCanvas
-    // is supported (Chrome/Edge for sure, Firefox 144+; Safari is iffy),
-    // pre-allocate srcCanvasRef at grid resolution and transfer its 2D
-    // context to the worker. The worker then writes WebGPU output directly
-    // to it via a present compute pipeline — no per-frame readback or
-    // postMessage of the colors buffer. Failure or unsupported envs fall
-    // back transparently: directRenderActiveRef stays false and the
-    // existing readback-then-putImageData path runs.
-    let canvasForWorker: OffscreenCanvas | undefined;
+    // P7 direct render: under WebGPU we eventually transfer srcCanvas's
+    // control to an OffscreenCanvas so the worker's WebGPU runtime can write
+    // straight to it via the present compute pipeline. We DEFER that transfer
+    // until the worker confirms via useWebGPUStatus that the runtime is up —
+    // until then srcCanvas stays a regular 2D canvas so the JS-fallback
+    // colors path (which the worker uses while async device init is in
+    // flight) can still putImageData onto it. Without this deferral, every
+    // worker init had a 50-500ms window where the user saw a frozen blank
+    // grid even while the worker was correctly evolving CPU state.
     directRenderActiveRef.current = false;
+    pendingCanvasAttach.current = false;
     // Drop any prior srcCanvas reference — if the previous worker init went
     // through the direct-render path, srcCanvasRef holds a transferred canvas
     // whose 2D context is permanently unavailable. Re-using it here would
     // make all later getImageData / drawImage calls fail silently (visible
     // symptom: GIF recording captures zero frames after a WebGPU→JS toggle).
-    srcCanvasRef.current = null;
+    {
+      const fresh = document.createElement('canvas');
+      fresh.width = w; fresh.height = h;
+      srcCanvasRef.current = fresh;
+    }
     const offscreenSupported = typeof HTMLCanvasElement !== 'undefined'
       && typeof (HTMLCanvasElement.prototype as { transferControlToOffscreen?: unknown }).transferControlToOffscreen === 'function';
+    // Mark that we want to attach a canvas once the worker reports ready.
+    // The actual transferControlToOffscreen + postMessage('attachCanvas')
+    // happens in the useWebGPUStatus handler.
     if (model.properties.useWebGPU && !webgpuResult.error && offscreenSupported) {
-      try {
-        // Always allocate a fresh srcCanvas so transferControlToOffscreen can
-        // succeed (a canvas can only be transferred once, and only if it has
-        // never had a 2D / WebGL context retrieved on the main thread).
-        const fresh = document.createElement('canvas');
-        fresh.width = w; fresh.height = h;
-        canvasForWorker = (fresh as HTMLCanvasElement & { transferControlToOffscreen: () => OffscreenCanvas }).transferControlToOffscreen();
-        srcCanvasRef.current = fresh;
-        directRenderActiveRef.current = true;
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn('[webgpu] OffscreenCanvas transfer failed; falling back to readback path:', e);
-        canvasForWorker = undefined;
-        directRenderActiveRef.current = false;
-      }
+      pendingCanvasAttach.current = true;
     }
     const initMsg: Record<string, unknown> = {
       type: 'init',
@@ -790,14 +828,11 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       useWebGPU: !!model.properties.useWebGPU,
       webgpuStopCheckInterval: Math.max(1, Math.floor(model.properties.webgpuStopCheckInterval ?? 1)),
     };
-    if (canvasForWorker) {
-      initMsg.webgpuCanvas = canvasForWorker;
-      initMsg.webgpuCanvasWidth = w;
-      initMsg.webgpuCanvasHeight = h;
-      worker.postMessage(initMsg, [canvasForWorker]);
-    } else {
-      worker.postMessage(initMsg);
-    }
+    // Canvas transfer is deferred to the useWebGPUStatus handler — see
+    // pendingCanvasAttach above. The init message never carries webgpuCanvas
+    // anymore; the worker's startWebGPUInit runs without a canvas, falls
+    // through to the readback path until attachCanvas arrives.
+    worker.postMessage(initMsg);
     workerRef.current = worker;
     if (import.meta.env?.DEV) (window as unknown as { __simWorker?: Worker }).__simWorker = worker;
     generationRef.current = 0;

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -937,21 +937,34 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
       initWorkerWithDimensions(model.properties.gridWidth, model.properties.gridHeight);
     } else {
       // Graph or indicator watch change only → soft recompile (preserves grid)
-      const result = compileGraph(model.graphNodes, model.graphEdges, model);
+      // The Resize button updates `gridWidth.current` / `gridHeight.current` but
+      // intentionally does NOT update model.properties (so the model isn't
+      // marked dirty for a temporary experiment). Mirror the dimsModel pattern
+      // from the full-reinit branch so the recompile sees the actual current
+      // dims — otherwise WebGPU bakes the OLD `total` into its bounds check
+      // and only the first N rows of the resized grid get computed (the
+      // "top stripe" symptom). JS / WASM are tolerant (total is a runtime
+      // arg there); only WebGPU exhibits the bug.
+      const curW = gridWidth.current;
+      const curH = gridHeight.current;
+      const dimsModel = (model.properties.gridWidth === curW && model.properties.gridHeight === curH)
+        ? model
+        : { ...model, properties: { ...model.properties, gridWidth: curW, gridHeight: curH } };
+      const result = compileGraph(dimsModel.graphNodes, dimsModel.graphEdges, dimsModel);
       setCompiledCode(buildFullCode(result));
       setCompileError(result.error ?? '');
       const wasmResult = (() => {
         try {
-          const layout = computeLayoutFromModel(model);
-          const viewerIds = buildViewerIds(model);
-          return compileGraphWasm(model.graphNodes, model.graphEdges, model, layout, viewerIds);
+          const layout = computeLayoutFromModel(dimsModel);
+          const viewerIds = buildViewerIds(dimsModel);
+          return compileGraphWasm(dimsModel.graphNodes, dimsModel.graphEdges, dimsModel, layout, viewerIds);
         } catch (e) {
           return { bytes: new Uint8Array(), minMemoryPages: 1, error: String((e as Error)?.message || e), viewerIds: {}, exports: [] };
         }
       })();
       const webgpuResult = (() => {
         try {
-          return compileGraphWebGPU(model.graphNodes, model.graphEdges, model);
+          return compileGraphWebGPU(dimsModel.graphNodes, dimsModel.graphEdges, dimsModel);
         } catch (e) {
           return { shaderCode: '', entryPoints: { step: 'step', outputMappings: [] as Array<{ mappingId: string; entry: string }> }, layout: null as never, error: String((e as Error)?.message || e) };
         }

--- a/src/simulator/SimulatorView.tsx
+++ b/src/simulator/SimulatorView.tsx
@@ -518,6 +518,20 @@ export function SimulatorView({ visible = true }: { visible?: boolean }) {
           lastGenSetTime.current = now;
         }
         draw();
+        // Under WebGPU direct render, drawImage(srcCanvas) reads the
+        // OffscreenCanvas placeholder's *last-composited* frame. The worker
+        // has just dispatched the present pass and posted stepped, but the
+        // browser's compositor may not have picked up that frame yet — so
+        // the immediate draw above can blit the *previous* frame. Schedule
+        // a follow-up draw on the next animation frame: by then the
+        // compositor has run, drawImage reads the new frame, and the user
+        // sees the actual result of paint / paste / clear / reset / etc.
+        // Without this, one-shot mutations under direct render leave the
+        // canvas showing stale post-Play state until the next user action.
+        // Cost is negligible (one extra drawImage at vsync rate).
+        if (directRenderActiveRef.current) {
+          requestAnimationFrame(() => draw());
+        }
 
         // GIF frame capture. Two source paths depending on render mode:
         // - Non-direct (JS / WASM, or WebGPU pre-P7): srcCanvas's 2D context

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -165,8 +165,13 @@ interface SetRecordingMsg { type: 'setRecording'; enabled: boolean }
  *  init can still putImageData onto a regular canvas. Worker switches to direct
  *  render upon receipt. */
 interface AttachCanvasMsg { type: 'attachCanvas'; canvas: OffscreenCanvas; width: number; height: number }
+/** One-shot colors readback for screenshot. Under WebGPU direct render the
+ *  main thread's srcCanvas is a transferred OffscreenCanvas placeholder whose
+ *  2D-context APIs (getImageData, toBlob) all fail; instead it asks the worker
+ *  for a fresh colors snapshot, builds an offscreen 2D canvas, and toBlob's. */
+interface RequestColorsSnapshotMsg { type: 'requestColorsSnapshot'; tag?: string }
 
-type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg | UpdateIndicatorsMsg | GetStateMsg | LoadStateMsg | ReadRegionMsg | WriteRegionMsg | ClearRegionMsg | SetUseWasmMsg | SetUseWebGPUMsg | ReadbackWebGPUMsg | ColorPassMsg | SetRecordingMsg | AttachCanvasMsg;
+type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg | UpdateIndicatorsMsg | GetStateMsg | LoadStateMsg | ReadRegionMsg | WriteRegionMsg | ClearRegionMsg | SetUseWasmMsg | SetUseWebGPUMsg | ReadbackWebGPUMsg | ColorPassMsg | SetRecordingMsg | AttachCanvasMsg | RequestColorsSnapshotMsg;
 
 // ---------------------------------------------------------------------------
 // State
@@ -672,6 +677,18 @@ function tryInstantiateWasmModule(bytes: Uint8Array | undefined, exportNames: st
  *  CPU → GPU (mutation handlers in step 6) or readback handlers that sync
  *  GPU → CPU (step 7 save state, step 14 linked indicators). */
 let gpuOwnsAttrs = false;
+
+/** Pull GPU → CPU iff the GPU is currently authoritative. Use before any code
+ *  path that READS the CPU `readAttrs` mirror for outgoing data (clipboard,
+ *  save state, JS-mode color pass, etc) — otherwise the read returns stale
+ *  pre-evolution data after Play under WebGPU. The `getState` and `paint`
+ *  handlers were the only ones that did this manually; this helper makes the
+ *  invariant uniform for all readers. */
+async function ensureCpuAttrsFresh(): Promise<void> {
+  if (!useWebGPU || !webgpuRuntime?.stepReady || !gpuOwnsAttrs) return;
+  await readbackAttrs(webgpuRuntime, readAttrs);
+  gpuOwnsAttrs = false;
+}
 
 function runStep(): void {
   // Wave 3: triple branch — WebGPU > WASM > JS. WebGPU only takes the
@@ -1185,6 +1202,14 @@ function randomizeGrid(): void {
   }
   resetIndicators();
   generation = 0;
+  // Under WebGPU the message handler is solely responsible for the post-mutation
+  // visual update — uploadAttrs + runColorPassWebGPU. If we ran runStep() here,
+  // it would route to runStepWebGPU which dispatches the GPU step shader against
+  // the STALE GPU attrsRead (CPU mutation hasn't been uploaded yet) AND increments
+  // generation. Net effect: gen counter shows 1 after a Randomize, and
+  // SetColorViewer-in-step viewers (e.g. MNCA "Decorated Trace") display a
+  // step OF the pre-randomize state instead of the random state itself.
+  if (useWebGPU && webgpuRuntime?.stepReady) return;
   // Prefer Output Mapping color pass (no generation advance) over runStep fallback
   const hasColorPassR = outputMappingFns.some(f => f.mappingId === activeViewer);
   if (hasColorPassR) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
@@ -1199,6 +1224,9 @@ function resetGrid(): void {
   }
   resetIndicators();
   generation = 0;
+  // Same reasoning as randomizeGrid — under WebGPU defer the visual update to
+  // the message handler. See randomizeGrid comment above.
+  if (useWebGPU && webgpuRuntime?.stepReady) return;
   const hasColorPassRs = outputMappingFns.some(f => f.mappingId === activeViewer);
   if (hasColorPassRs) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
 }
@@ -1667,7 +1695,12 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         uploadActiveViewer(webgpuRuntime, viewerIdMap[activeViewer] ?? -1);
         syncIndicatorsCpuToGpu();
         gpuOwnsAttrs = false;
-        runColorPassWebGPU();
+        // refreshColorsAfterInputWebGPU dispatches the OM pipeline if the active
+        // viewer has one; falls back to a step shader (which writes colors via
+        // SetColorViewer-in-step) for viewers like MNCA's "Decorated Trace".
+        // Without this fallback, no-OM viewers wouldn't visually update on
+        // randomize/reset under WebGPU.
+        refreshColorsAfterInputWebGPU();
         finalizeStepWebGPU({ needColors: true }).then(() => sendColors())
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] randomize colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
@@ -1685,7 +1718,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         uploadActiveViewer(webgpuRuntime, viewerIdMap[activeViewer] ?? -1);
         syncIndicatorsCpuToGpu();
         gpuOwnsAttrs = false;
-        runColorPassWebGPU();
+        refreshColorsAfterInputWebGPU();
         finalizeStepWebGPU({ needColors: true }).then(() => sendColors())
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] reset colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
@@ -1725,20 +1758,55 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
     }
 
     case 'setUseWasm': {
-      useWasm = !!msg.enabled;
-      // If the user just turned WASM on, make sure WebGPU is off (mutual
-      // exclusion mirrors the UI radio group).
-      if (useWasm && useWebGPU) {
-        useWebGPU = false;
-        destroyWebGPURuntime(webgpuRuntime);
-        webgpuRuntime = null;
+      const enableWasm = !!msg.enabled;
+      // If the user just turned WASM on, drain GPU state to CPU before tearing
+      // down the runtime — otherwise gpuOwnsAttrs CPU mirror is stale and the
+      // first JS/WASM step runs against pre-Play data. Then enforce mutual
+      // exclusion (WASM on → WebGPU off).
+      if (enableWasm && useWebGPU && webgpuRuntime?.stepReady) {
+        const rt = webgpuRuntime;
+        void (async () => {
+          try {
+            if (gpuOwnsAttrs) await readbackAttrs(rt, readAttrs);
+            gpuOwnsAttrs = false;
+          } catch (e) {
+            self.postMessage({ type: 'error', message: '[webgpu] setUseWasm drain failed: ' + ((e instanceof Error) ? e.message : String(e)) });
+          }
+          useWasm = enableWasm;
+          useWebGPU = false;
+          destroyWebGPURuntime(webgpuRuntime);
+          webgpuRuntime = null;
+          self.postMessage({ type: 'useWasmStatus', enabled: useWasm, ready: wasmStepFn !== null });
+        })();
+        break;
       }
+      useWasm = enableWasm;
       self.postMessage({ type: 'useWasmStatus', enabled: useWasm, ready: wasmStepFn !== null });
       break;
     }
 
     case 'setUseWebGPU': {
-      useWebGPU = !!msg.enabled;
+      const enableWebGPU = !!msg.enabled;
+      // Toggling WebGPU OFF: drain GPU → CPU AND mark the runtime's directRender
+      // flag false so any subsequent sendColors falls through to the colors-
+      // transfer path (otherwise sendColors keeps short-circuiting on the live
+      // runtime's stale directRender bit and the canvas freezes silently).
+      if (!enableWebGPU && useWebGPU && webgpuRuntime?.stepReady) {
+        const rt = webgpuRuntime;
+        void (async () => {
+          try {
+            if (gpuOwnsAttrs) await readbackAttrs(rt, readAttrs);
+            gpuOwnsAttrs = false;
+          } catch (e) {
+            self.postMessage({ type: 'error', message: '[webgpu] setUseWebGPU drain failed: ' + ((e instanceof Error) ? e.message : String(e)) });
+          }
+          useWebGPU = false;
+          if (webgpuRuntime) webgpuRuntime.directRender = false;
+          self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: false, directRender: false });
+        })();
+        break;
+      }
+      useWebGPU = enableWebGPU;
       if (useWebGPU && useWasm) {
         // Mutual exclusion: WebGPU wins.
         useWasm = false;
@@ -1749,6 +1817,38 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
 
     case 'setRecording': {
       recording = !!msg.enabled;
+      break;
+    }
+
+    case 'requestColorsSnapshot': {
+      // One-shot colors readback for screenshot under WebGPU direct render.
+      // Reads back the current GPU colors buffer and posts the bytes to the
+      // main thread. Tag echoed back so the requester can match the response.
+      const tag = msg.tag ?? '';
+      const rt = webgpuRuntime;
+      if (useWebGPU && rt?.stepReady && rt.directRender) {
+        void (async () => {
+          try {
+            await readbackColors(rt, colors);
+            const snap = new Uint8ClampedArray(colors);
+            self.postMessage(
+              { type: 'colorsSnapshot', tag, w: width, h: height, colors: snap },
+              { transfer: [snap.buffer] },
+            );
+          } catch (e) {
+            self.postMessage({ type: 'error', message: '[webgpu] colors snapshot failed: ' + ((e instanceof Error) ? e.message : String(e)) });
+            self.postMessage({ type: 'colorsSnapshot', tag, w: width, h: height });
+          }
+        })();
+      } else {
+        // No WebGPU / no direct render: CPU `colors` mirror is already current
+        // (sendColors path keeps it populated). Just ship a copy.
+        const snap = new Uint8ClampedArray(colors);
+        self.postMessage(
+          { type: 'colorsSnapshot', tag, w: width, h: height, colors: snap },
+          { transfer: [snap.buffer] },
+        );
+      }
       break;
     }
 
@@ -1898,13 +1998,22 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
       }
-      const hasColorPassCp = outputMappingFns.some(f => f.mappingId === activeViewer);
-      if (hasColorPassCp) {
-        runColorPass();
-      } else {
-        writeDefaultColors();
-      }
-      sendColors();
+      // JS fallback: pull GPU → CPU first if a stale runtime is hanging around
+      // with gpuOwnsAttrs=true (e.g. WebGPU init succeeded, ran steps, then a
+      // recompile error left useWebGPU=true but stepReady=false).
+      void (async () => {
+        try { await ensureCpuAttrsFresh(); } catch (e) {
+          self.postMessage({ type: 'error', message: '[webgpu] colorPass readback failed: ' + ((e instanceof Error) ? e.message : String(e)) });
+          return;
+        }
+        const hasColorPassCp = outputMappingFns.some(f => f.mappingId === activeViewer);
+        if (hasColorPassCp) {
+          runColorPass();
+        } else {
+          writeDefaultColors();
+        }
+        sendColors();
+      })();
       break;
     }
 
@@ -2025,27 +2134,37 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
     case 'readRegion': {
       // Snapshot every cell attribute over the (row, col, w, h) rectangle.
       // Cells outside [0, width) × [0, height) are replaced by the attribute's default value.
-      const attrBuffers: Record<string, { type: string; buffer: ArrayBuffer }> = {};
-      const transfers: ArrayBuffer[] = [];
-      const size = msg.w * msg.h;
-      for (const attr of cellAttrs) {
-        const out = createTypedArray(attr.type, size);
-        const dv = defaultValue(attr);
-        if (dv !== 0) out.fill(dv);
-        const src = readAttrs[attr.id]!;
-        for (let dr = 0; dr < msg.h; dr++) {
-          const srcRow = msg.row + dr;
-          if (srcRow < 0 || srcRow >= height) continue;
-          for (let dc = 0; dc < msg.w; dc++) {
-            const srcCol = msg.col + dc;
-            if (srcCol < 0 || srcCol >= width) continue;
-            out[dr * msg.w + dc] = src[srcRow * width + srcCol]!;
-          }
+      // Under WebGPU after Play, `gpuOwnsAttrs` is true and the CPU mirror is
+      // stale — pull it back before reading or Ctrl+C / Ctrl+X copy pre-Play
+      // values instead of the visible state.
+      void (async () => {
+        const m = msg;
+        try { await ensureCpuAttrsFresh(); } catch (e) {
+          self.postMessage({ type: 'error', message: '[webgpu] readRegion readback failed: ' + ((e instanceof Error) ? e.message : String(e)) });
+          return;
         }
-        attrBuffers[attr.id] = { type: attr.type, buffer: out.buffer };
-        transfers.push(out.buffer);
-      }
-      self.postMessage({ type: 'regionData', w: msg.w, h: msg.h, attributes: attrBuffers }, { transfer: transfers });
+        const attrBuffers: Record<string, { type: string; buffer: ArrayBuffer }> = {};
+        const transfers: ArrayBuffer[] = [];
+        const size = m.w * m.h;
+        for (const attr of cellAttrs) {
+          const out = createTypedArray(attr.type, size);
+          const dv = defaultValue(attr);
+          if (dv !== 0) out.fill(dv);
+          const src = readAttrs[attr.id]!;
+          for (let dr = 0; dr < m.h; dr++) {
+            const srcRow = m.row + dr;
+            if (srcRow < 0 || srcRow >= height) continue;
+            for (let dc = 0; dc < m.w; dc++) {
+              const srcCol = m.col + dc;
+              if (srcCol < 0 || srcCol >= width) continue;
+              out[dr * m.w + dc] = src[srcRow * width + srcCol]!;
+            }
+          }
+          attrBuffers[attr.id] = { type: attr.type, buffer: out.buffer };
+          transfers.push(out.buffer);
+        }
+        self.postMessage({ type: 'regionData', w: m.w, h: m.h, attributes: attrBuffers }, { transfer: transfers });
+      })();
       break;
     }
 

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -887,6 +887,24 @@ function refreshColorsAfterInputWebGPU(): void {
   runStepWebGPU();
 }
 
+/** JS / WASM analogue of refreshColorsAfterInputWebGPU. Same intent: after any
+ *  CPU-side mutation (paint, paste, clear, randomize, reset, image import),
+ *  refresh the CPU `colors` mirror so the next sendColors ships up-to-date
+ *  pixels. Prefer the active viewer's Output Mapping (no generation advance);
+ *  fall back to one Step (advances gen by 1; required for viewers like MNCA
+ *  that emit colors via SetColorViewer-in-step); fall back to the bool-attr
+ *  default coloring. ALL JS/WASM mutation handlers should call this — without
+ *  it, no-OM viewers display pre-mutation colors after Ctrl+V / Ctrl+X. */
+function refreshColorsAfterInputJS(): void {
+  if (outputMappingFns.some(f => f.mappingId === activeViewer)) {
+    runColorPass();
+  } else if (stepFn) {
+    runStep();
+  } else {
+    writeDefaultColors();
+  }
+}
+
 /** Patch the GPU `attrsRead` buffer for a set of cell indices, copying their
  *  current values from the CPU `readAttrs` mirror. Used by mutation handlers
  *  (paint, writeRegion, clearRegion) to update only the touched cells without
@@ -1210,9 +1228,7 @@ function randomizeGrid(): void {
   // SetColorViewer-in-step viewers (e.g. MNCA "Decorated Trace") display a
   // step OF the pre-randomize state instead of the random state itself.
   if (useWebGPU && webgpuRuntime?.stepReady) return;
-  // Prefer Output Mapping color pass (no generation advance) over runStep fallback
-  const hasColorPassR = outputMappingFns.some(f => f.mappingId === activeViewer);
-  if (hasColorPassR) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
+  refreshColorsAfterInputJS();
 }
 
 function resetGrid(): void {
@@ -1227,8 +1243,7 @@ function resetGrid(): void {
   // Same reasoning as randomizeGrid — under WebGPU defer the visual update to
   // the message handler. See randomizeGrid comment above.
   if (useWebGPU && webgpuRuntime?.stepReady) return;
-  const hasColorPassRs = outputMappingFns.some(f => f.mappingId === activeViewer);
-  if (hasColorPassRs) { runColorPass(); } else if (stepFn) { runStep(); } else { writeDefaultColors(); }
+  refreshColorsAfterInputJS();
 }
 
 function compileFns(
@@ -1640,7 +1655,6 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         }
 
         // Update display.
-        const hasColorPass = outputMappingFns.some(f => f.mappingId === activeViewer);
         const webgpuPaint = useWebGPU && webgpuRuntime?.stepReady;
         if (webgpuPaint && webgpuRuntime) {
           // Patch only the painted cells — the rest of the GPU buffer holds
@@ -1659,13 +1673,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
             .catch(e => self.postMessage({ type: 'error', message: '[webgpu] paint colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
           return;
         }
-        if (hasColorPass) {
-          runColorPass();
-        } else if (stepFn) {
-          runStep();
-        } else {
-          writeDefaultColors();
-        }
+        refreshColorsAfterInputJS();
         sendColors();
       };
 
@@ -1966,7 +1974,6 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         }
       }
       // Update display.
-      const hasColorPassImg = outputMappingFns.some(f => f.mappingId === activeViewer);
       const webgpuImport = useWebGPU && webgpuRuntime?.stepReady;
       if (webgpuImport && webgpuRuntime) {
         uploadAttrs(webgpuRuntime, readAttrs);
@@ -1977,13 +1984,7 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] importImage colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
       }
-      if (hasColorPassImg) {
-        runColorPass();
-      } else if (stepFn) {
-        runStep();
-      } else {
-        writeDefaultColors();
-      }
+      refreshColorsAfterInputJS();
       sendColors();
       break;
     }
@@ -2214,9 +2215,11 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] writeRegion colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
       }
-      if (outputMappingFns.some(f => f.mappingId === activeViewer)) {
-        runColorPass();
-      }
+      // JS / WASM fallback — without the runStep fallback for no-OM viewers,
+      // pasting on viewers like MNCA "Decorated Trace" leaves the canvas
+      // showing pre-paste colors (the colors buffer is only refreshed by the
+      // step shader on those viewers).
+      refreshColorsAfterInputJS();
       sendColors();
       break;
     }
@@ -2260,9 +2263,9 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
           .catch(e => self.postMessage({ type: 'error', message: '[webgpu] clearRegion colorPass failed: ' + ((e instanceof Error) ? e.message : String(e)) }));
         break;
       }
-      if (outputMappingFns.some(f => f.mappingId === activeViewer)) {
-        runColorPass();
-      }
+      // JS / WASM fallback — same shape as writeRegion above. No-OM viewers
+      // rely on the step shader to repaint colors.
+      refreshColorsAfterInputJS();
       sendColors();
       break;
     }

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -12,7 +12,7 @@ import {
   createWebGPURuntime, destroyWebGPURuntime, isWebGPUAvailable, shaderHashOf,
   setupBuffersAndPipelines, uploadAttrs, uploadNeighborIndices,
   uploadModelAttrs, uploadActiveViewer, uploadIndicators, uploadIndicatorsAt, dispatchStep,
-  dispatchOutputMapping, dispatchColorPassAndPresent, readbackAttrs, readbackColors,
+  dispatchOutputMapping, dispatchColorPassAndPresent, presentToCanvas, readbackAttrs, readbackColors,
   readbackBatched, unpackAttrsFromReadback, unpackAttrFromReadback, resetStopFlag, seedRngState,
   setupReductionPipelines, dispatchReductions, setupDirectRender,
   type WebGPURuntime, type ReadbackRegion,
@@ -880,11 +880,30 @@ function runColorPassWebGPU(): boolean {
  *  Output Mapping pipeline, dispatch it. Otherwise, run one Step — models that
  *  emit colors via SetColorViewer-in-step (e.g. MNCA's "Case Colored") rely on
  *  the step to update colors. Generation advances by 1 in the fallback case,
- *  which is the documented behaviour for these models on user interaction. */
+ *  which is the documented behaviour for these models on user interaction.
+ *
+ *  CRITICAL ordering: for no-OM viewers we MUST dispatch the step BEFORE the
+ *  present pass — otherwise the present blits the stale colors that were
+ *  there before the mutation, then the step writes new colors that never
+ *  reach the canvas. dispatchColorPassAndPresent runs OM (which writes
+ *  colors) and present in one encoder, so ordering is correct for OM
+ *  viewers; but it dispatches present unconditionally under direct render
+ *  even when the OM pipeline doesn't exist, so we have to gate which path
+ *  we take based on whether an OM pipeline actually exists.
+ */
 function refreshColorsAfterInputWebGPU(): void {
-  if (!webgpuRuntime || !webgpuRuntime.stepReady) return;
-  if (runColorPassWebGPU()) return;
+  const rt = webgpuRuntime;
+  if (!rt || !rt.stepReady) return;
+  const omExists = rt.entryPoints.outputMappings.some(o => o.mappingId === activeViewer);
+  if (omExists) {
+    runColorPassWebGPU();
+    return;
+  }
+  // No OM pipeline → step shader populates colors via SetColorViewer-in-step.
+  // Dispatch step FIRST so colorsBuf is fresh, THEN present so the canvas
+  // texture picks it up.
   runStepWebGPU();
+  presentToCanvas(rt);
 }
 
 /** JS / WASM analogue of refreshColorsAfterInputWebGPU. Same intent: after any

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -14,7 +14,7 @@ import {
   uploadModelAttrs, uploadActiveViewer, uploadIndicators, uploadIndicatorsAt, dispatchStep,
   dispatchOutputMapping, dispatchColorPassAndPresent, readbackAttrs, readbackColors,
   readbackBatched, unpackAttrsFromReadback, unpackAttrFromReadback, resetStopFlag, seedRngState,
-  setupReductionPipelines, dispatchReductions,
+  setupReductionPipelines, dispatchReductions, setupDirectRender,
   type WebGPURuntime, type ReadbackRegion,
 } from './webgpuRuntime';
 import { decodeReductions, gpuHandledIds, gpuHandledAttrIds } from './webgpuReduce';
@@ -160,8 +160,13 @@ interface ColorPassMsg { type: 'colorPass'; activeViewer: string }
  *  on the main thread). Cost (the per-frame readback) is paid only while
  *  recording. */
 interface SetRecordingMsg { type: 'setRecording'; enabled: boolean }
+/** Late-binding canvas attach: the main thread defers transferControlToOffscreen
+ *  until the WebGPU runtime is confirmed ready, so the JS-fallback period during
+ *  init can still putImageData onto a regular canvas. Worker switches to direct
+ *  render upon receipt. */
+interface AttachCanvasMsg { type: 'attachCanvas'; canvas: OffscreenCanvas; width: number; height: number }
 
-type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg | UpdateIndicatorsMsg | GetStateMsg | LoadStateMsg | ReadRegionMsg | WriteRegionMsg | ClearRegionMsg | SetUseWasmMsg | SetUseWebGPUMsg | ReadbackWebGPUMsg | ColorPassMsg | SetRecordingMsg;
+type WorkerMsg = InitMsg | StepMsg | PaintMsg | RandomizeMsg | ResetMsg | RecompileMsg | UpdateModelAttrsMsg | ImportImageMsg | UpdateIndicatorsMsg | GetStateMsg | LoadStateMsg | ReadRegionMsg | WriteRegionMsg | ClearRegionMsg | SetUseWasmMsg | SetUseWebGPUMsg | ReadbackWebGPUMsg | ColorPassMsg | SetRecordingMsg | AttachCanvasMsg;
 
 // ---------------------------------------------------------------------------
 // State
@@ -292,7 +297,7 @@ function startWebGPUInit(
   // expensive async device + shaderModule + pipeline rebuild — saves hundreds
   // of ms on graph-only edits where the user isn't actually changing the rule.
   if (shaderCode && webgpuRuntime?.stepReady && shaderHashOf(shaderCode) === webgpuRuntime.shaderHash) {
-    self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: true });
+    self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: true, directRender: webgpuRuntime.directRender });
     return;
   }
   // P7 — salvage any direct-render canvas attached to the previous runtime.
@@ -358,7 +363,7 @@ function startWebGPUInit(
       }
       // eslint-disable-next-line no-console
       console.log(`[webgpu] runtime ready: device + shader + buffers + step pipeline (${rt.entryPoints.outputMappings.length} viewer pipeline(s) lazily built)`);
-      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: rt.stepReady });
+      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: rt.stepReady, directRender: rt.directRender });
     })
     .catch((e: unknown) => {
       // Same staleness check on the failure path — don't clobber the newer
@@ -367,7 +372,7 @@ function startWebGPUInit(
       webgpuRuntime = null;
       const msg = (e instanceof Error) ? e.message : String(e);
       self.postMessage({ type: 'error', message: '[webgpu] init failed: ' + msg });
-      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: false });
+      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: false, directRender: false });
     });
 }
 
@@ -1738,12 +1743,36 @@ self.onmessage = (e: MessageEvent<WorkerMsg>) => {
         // Mutual exclusion: WebGPU wins.
         useWasm = false;
       }
-      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: webgpuRuntime?.stepReady ?? false });
+      self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: webgpuRuntime?.stepReady ?? false, directRender: webgpuRuntime?.directRender ?? false });
       break;
     }
 
     case 'setRecording': {
       recording = !!msg.enabled;
+      break;
+    }
+
+    case 'attachCanvas': {
+      // Main thread deferred the canvas transfer until WebGPU runtime is up.
+      // Wire it into the existing runtime via setupDirectRender, then dispatch
+      // an immediate color pass + present so the canvas isn't blank when the
+      // main thread drawImage's it on the next frame.
+      if (!webgpuRuntime || !webgpuRuntime.stepReady) {
+        self.postMessage({ type: 'error', message: '[webgpu] attachCanvas before runtime ready' });
+        break;
+      }
+      webgpuRuntime.canvas = msg.canvas;
+      try {
+        setupDirectRender(webgpuRuntime);
+        if (webgpuRuntime.directRender) {
+          dispatchColorPassAndPresent(webgpuRuntime, activeViewer);
+          self.postMessage({ type: 'stepped', generation });
+          self.postMessage({ type: 'useWebGPUStatus', enabled: useWebGPU, ready: true, directRender: true });
+        }
+      } catch (e) {
+        const m = (e instanceof Error) ? e.message : String(e);
+        self.postMessage({ type: 'error', message: '[webgpu] attachCanvas failed: ' + m });
+      }
       break;
     }
 

--- a/src/simulator/engine/sim.worker.ts
+++ b/src/simulator/engine/sim.worker.ts
@@ -895,7 +895,17 @@ function patchWebGPUCells(idxs: ArrayLike<number>): void {
     if (v > maxIdx) maxIdx = v;
   }
   const rangeLen = maxIdx - minIdx + 1;
-  const useBatch = rangeLen <= idxs.length * 4;
+  // The batched path uploads all cells in [minIdx, maxIdx], pulling the
+  // "in-between" (not-touched) cells from CPU readAttrs. That's a no-op
+  // when the mirror is current (post-reset / pre-step). After a step under
+  // WebGPU, gpuOwnsAttrs=true and the CPU mirror is stale — uploading
+  // those in-between cells would overwrite the GPU's live post-step state
+  // with stale CPU values. Symptom: pasting a brush-wide rectangle after
+  // play produces a brush-tall "wipe" stripe across the entire row, where
+  // the cells between paste columns get clobbered. Force per-cell whenever
+  // the mirror could be stale; the per-cell cost is negligible for typical
+  // brush / paste sizes (a few queue.writeBuffer calls per attr).
+  const useBatch = !gpuOwnsAttrs && rangeLen <= idxs.length * 4;
   for (const attr of cellAttrs) {
     const layoutAttr = rt.layout.attrs.find(a => a.id === attr.id);
     if (!layoutAttr) continue;

--- a/src/simulator/engine/webgpuRuntime.ts
+++ b/src/simulator/engine/webgpuRuntime.ts
@@ -435,7 +435,7 @@ fn presentColors(@builtin(global_invocation_id) gid: vec3<u32>) {
 `;
 }
 
-function setupDirectRender(rt: WebGPURuntime): void {
+export function setupDirectRender(rt: WebGPURuntime): void {
   if (!rt.canvas || !rt.colorsBuf) return;
   const ctx = rt.canvas.getContext('webgpu') as GPUCanvasContext | null;
   if (!ctx) throw new Error('OffscreenCanvas.getContext("webgpu") returned null');


### PR DESCRIPTION
## Summary
- **WebGPU correctness sweep** (7 commits): full audit-driven fix for CPU/GPU/canvas state-drift bugs that surfaced after the Wave 3 landing. Brush, paste, clear, reset, randomize, screenshot, copy/cut, and Resize now produce the correct visible frame across both OM-event and SetColorViewer-in-step viewers. Two root causes addressed uniformly: CPU `readAttrs` reads without `gpuOwnsAttrs` checks (new `ensureCpuAttrsFresh` helper at every read site), and the main thread claiming direct render live before the worker confirms (two-phase `attachCanvas` handshake). Specific fixes include: deferred canvas transfer so the JS-fallback init window stays interactive; `dimsModel` in the soft-recompile branch (top-stripe-after-Resize bug); `patchWebGPUCells` per-cell upload when the CPU mirror is stale (paste-after-Play wipe stripe); step-then-present ordering for no-OM viewers (post-mutation canvas update); follow-up rAF draw so the compositor catches up after one-shot mutations.
- **JS/WASM parity**: `writeRegion` / `clearRegion` now also dispatch the step fallback on no-OM viewers, matching paint / import / randomize. Extracted into `refreshColorsAfterInputJS`.
- **Modeler/Simulator UX**: interpolation curve dropdowns on Color Interpolate / Proportion Map (Linear, Smoothstep, Ease-In/Out Quad, Exponential, Logarithmic) wired across all three compile targets; redesigned Palette with vertical Nodes/Macros split, draggable splitter, and List/Visual toggle (mini-card preview mode); hovered-cell coordinates chip in the stats overlay; macro instances bubble up internal warning counts; Space toggles Palette, Esc closes the right panel; Set/Update Indicator nodes recolored to group with the attribute-write family.
- **Docs**: new `docs/HUGE_GRID_OPTIMIZATIONS.md` covering implicit sparse neighbor lookup, tile-based dispatch with workgroup-shared memory, and sub-word packing for bool / small-tag attributes — three deferred techniques for pushing past today's ~5000² ceiling.

## Test plan
- [ ] WebGPU: paint / paste / clear / reset / randomize on both OM viewers (GoL Trace) and no-OM viewers (MNCA Case Colored, Decorated Trace) — canvas reflects post-mutation state immediately
- [ ] WebGPU: Resize then immediately brush / randomize — interactions visually live during the init window
- [ ] WebGPU: Resize then edit a node config and return — full grid renders, no top-stripe black band
- [ ] WebGPU: Ctrl+C after Play returns evolved state, not pre-Play snapshot; paste a wide rectangle after Play — no horizontal wipe stripe
- [ ] WebGPU: screenshot button produces a valid PNG
- [ ] JS/WASM: paste / clear on no-OM viewers refreshes the display (gen advances by 1, matching paint)
- [ ] Color Interpolate / Proportion Map: each of the 5 curves produces correct interpolation under JS, WASM, and WebGPU
- [ ] Palette: List ↔ Visual toggle, splitter drag, position persists across reload
- [ ] Simulator stats overlay: hovered-cell chip shows Cell (col, row) at 1×1 brush and a range at larger sizes
- [ ] Modeler: macro with a misconfigured internal node shows "<N> internal warning(s)" on the macro instance